### PR TITLE
chore(deploy): include game bundle and styles in gh-pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build with Astro
         run: bun run build
 
+      - name: Build game bundle
+        run: bun run build:game
+
       - name: Setup Pagefind
         run: bunx pagefind --site dist --output-subdir pagefind
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "bunx astro dev",
     "build": "bunx astro build",
+    "build:game": "bunx vite build --config vite.game.config.js",
     "preview": "bunx astro preview",
     "optimize": "bunx astro build --optimize",
     "lint": "bunx prettier --write .",

--- a/vite.game.config.js
+++ b/vite.game.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  publicDir: false, // Don't copy public dir assets
   build: {
     lib: {
       entry: "./src/game/index.js",
@@ -12,6 +13,7 @@ export default defineConfig({
       external: [],
       output: {
         dir: "./dist/game",
+        entryFileNames: "game-engine.js", // Fixed filename for predictable URL
       },
     },
   },


### PR DESCRIPTION
## Summary
- Added game bundle build step to GitHub Actions workflow to ensure game-engine.js is included in Pages deployment
- Updated package.json with build:game script for building the game bundle via Vite
- Improved vite.game.config.js to prevent copying unnecessary public assets and ensure predictable output filename

## Files changed
- `.github/workflows/deploy.yml`: Added game bundle build step after Astro build
- `package.json`: Added "build:game" script
- `vite.game.config.js`: Set publicDir to false and fixed output filename

## Tests run and results
- ✅ Astro build: Successful (4 pages built, Pagefind indexed)
- ✅ Game bundle build: Successful (48.56 kB bundle at dist/game/game-engine.js)
- ✅ Unit tests: All 55 tests passed
- ✅ Path verification: Game engine available at /game/game-engine.js as expected by MiniGame.astro

## Post-merge steps
None required - GitHub Actions will automatically build and deploy both the Astro site and game bundle on merge.