### PR TITLE
Fix: Mobile layout horizontal overflow on homepage

### DIFF
--- a/src/components/game/MiniGame.astro
+++ b/src/components/game/MiniGame.astro
@@ -3,10 +3,10 @@
 // SSR-safe Astro component that lazy-loads the GameEngine on visibility or user gesture
 ---
 
-<div id="mini-game-root" class="game-container w-full max-w-2xl mx-auto p-4" role="region" aria-label="Code Runner mini game">
+<div id="mini-game-root" class="game-container w-full max-w-2xl mx-auto" role="region" aria-label="Code Runner mini game">
   <!-- SSR fallback / placeholder -->
   <div class="bg-tokyo-surface border-2 border-gameboy-light rounded-lg p-4 text-center">
-    <div class="mx-auto max-w-xs">
+    <div class="mx-auto w-full" style="max-width: min(320px, 100%)">
       <div id="game-screen" class="game-screen bg-gameboy-darkest rounded relative mx-auto" style="width:100%;">
         <canvas id="mini-game-canvas" width="240" height="216" aria-hidden="true" class="pixel-perfect w-full h-auto mx-auto block" style="aspect-ratio: 240 / 216;"></canvas>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -101,10 +101,9 @@ const skills = [
         </div>
       </section>
       
-      <!-- Mini Game Section -->
       <section class="mb-24 text-center">
         <h2 class="text-2xl font-pixel text-gameboy-lightest mb-12">TAKE A BREAK</h2>
-        <div class="inline-block p-4 bg-tokyo-surface border-2 border-tokyo-border rounded-xl">
+        <div class="inline-block bg-tokyo-surface border-2 border-tokyo-border rounded-xl overflow-hidden">
            <MiniGame class="mx-auto" />
         </div>
       </section>


### PR DESCRIPTION
## Problem
Fixed horizontal overflow issue causing left-skewed content on mobile devices (Pixel 9a).

## Root Cause
Two sources of padding were causing the issue:
- MiniGame component root container had `p-4` padding
- Homepage wrapper div around MiniGame also had `p-4` padding

Combined (32px total on each side), this exceeded narrow mobile viewports.

## Changes
- ✅ Removed `p-4` from MiniGame root container in `MiniGame.astro`
- ✅ Removed `p-4` from homepage wrapper in `index.astro`
- ✅ Updated max-width to use `min(320px, 100%)` for responsive behavior
- ✅ Added `overflow-hidden` to wrapper for proper clipping

## Testing
- ✅ Build completed successfully
- ✅ Projects and blog pages unaffected

Fixes the issue where content was skewed left on narrow viewports.