### PR TITLE
feat: Portfolio update with games page and new content

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -13,6 +13,7 @@ import SearchBar from '../ui/SearchBar.astro';
       <div class="hidden md:flex items-center gap-8">
         <a href="/" class="text-tokyo-text hover:text-gameboy-light transition-colors">Home</a>
         <a href="/projects" class="text-tokyo-text hover:text-gameboy-light transition-colors">Projects</a>
+        <a href="/games" class="text-tokyo-text hover:text-gameboy-light transition-colors">🎮 Games</a>
         <a href="/blog" class="text-tokyo-text hover:text-gameboy-light transition-colors">Blog</a>
       </div>
       

--- a/src/content/blog/agentic-sdlc-journey.md
+++ b/src/content/blog/agentic-sdlc-journey.md
@@ -1,0 +1,135 @@
+---
+title: "Building an Agentic SDLC Framework (Without Losing My Mind)"
+description: "The chaotic, occasionally painful, and ultimately rewarding journey of building an AI-powered SDLC framework for regulated environments."
+pubDate: 2026-03-15
+heroImage: "/assets/images/blog/sdlc-journey.png"
+tags: ["ai", "sdlc", "compliance", "governance", "agentic"]
+---
+
+# Building an Agentic SDLC Framework (Without Losing My Mind)
+
+*Or: How I Learned to Stop Worrying and Love the Audit Trail*
+
+So there I was, staring at a blank VS Code window, thinking: "How hard could it be to build an AI-powered SDLC framework?" 
+
+Famous last words, right?
+
+## The Problem That Started It All
+
+I work in a regulated environment (financial services, if you're curious). We have auditors. We have compliance officers. We have people whose entire job is to ask "but what if...?" questions at 4:45 PM on a Friday.
+
+And here's the thing about regulated environments: **speed and compliance are usually enemies**. The faster you want to move, the more paperwork you need to file. It's like trying to sprint through a swimming pool filled with Jell-O.
+
+I kept seeing these amazing AI coding demos on Twitter. "Watch Claude Code build an entire app in 5 minutes!" Yeah, well, try explaining that to someone who needs a paper trail for every semicolon.
+
+## The "Simple" Idea
+
+What if we could have both? What if AI could help us move fast AND generate all the audit artifacts automatically?
+
+The concept was simple:
+1. AI agents handle the coding
+2. Every decision gets logged
+3. Security scans happen automatically
+4. Documentation writes itself
+5. Auditors get their paper trail without slowing us down
+
+Simple, right? 
+
+*Laughs in scope creep*
+
+## The Reality Check (Week 2)
+
+By week two, I had learned some things:
+
+**Lesson #1: AI agents are enthusiastic toddlers.** They'll happily do exactly what you asked for, which is rarely what you actually need. "Please implement user authentication" somehow turned into a system that authenticated users... against a hardcoded JSON file... in production.
+
+**Lesson #2: Governance is hard because people are messy.** I spent three days just trying to define what "approval" meant. Does a Slack message count? An email? A nod across the room? (Spoiler: only the last one if you're wearing a compliance officer hat at the time.)
+
+**Lesson #3: Security scans are opinionated.** I hooked up every scanner I could find. SonarQube. Semgrep. Bandit. They disagreed. A lot. One tool's "critical vulnerability" was another's "meh, probably fine." Getting them to agree felt like negotiating peace in the Middle East.
+
+## The Breakthrough (Week 6)
+
+Around week six, I had what I can only describe as a "divine intervention from the coffee gods." 
+
+I was debugging why our agent kept generating documentation in Comic Sans (don't ask), when I realized: **the framework needed to be opinionated**. Not just about code, but about the entire process.
+
+We defined "The FRAME Loop":
+- **F**ocus: What are we actually building?
+- **R**equirements: What does it need to do?
+- **A**utomate: Let the agents handle implementation
+- **M**easure: Did it work?
+- **E**valuate: Should we ship it?
+
+Each step generates artifacts. Each artifact gets logged. Each log entry is immutable. Auditors love immutable.
+
+## The Funny Bits (Because Otherwise I'd Cry)
+
+**The Time the Agent Generated 47 Versions of the Same Function**
+
+I asked for "a function to validate email addresses." The agent got... enthusiastic. It generated:
+- A regex version
+- A "send a test email" version  
+- A "check against known disposable email domains" version
+- A "use an external API" version
+- A "block all emails from providers starting with vowels" version (???)
+- 42 variations combining the above
+
+I now have a `validateEmail_v47_final_ACTUAL_final.ts` file in my codebase. I'm afraid to delete it.
+
+**The Compliance Officer Who Asked If AI Could Have a Conflict of Interest**
+
+"Could the AI be... biased?" 
+
+"It's a language model, not a board member."
+
+"But what if it prefers Python over C#?"
+
+"...I think we're okay."
+
+## What Actually Worked
+
+After all the chaos, here's what actually made a difference:
+
+**1. Structured Prompts Beat Clever Prompts**
+
+I spent way too long trying to craft the "perfect" prompt. Turns out, giving the agent a template to fill out works way better than asking it to "be creative."
+
+**2. Human-in-the-Loop Isn't a Bug, It's a Feature**
+
+Early on, I tried to automate everything. Bad idea. Now we have checkpoints where humans must approve. The agents don't mind. The auditors definitely don't mind.
+
+**3. Documentation Should Be a Side Effect, Not a Task**
+
+If you're writing docs after the code is done, you're doing it wrong. Every code change should update the docs automatically. We use AI to generate first drafts, humans to refine.
+
+**4. Security Scanning Should Happen Before Humans See Code**
+
+Catching vulnerabilities in PR review is too late. We scan in the agent's workspace, before the code even hits git. Agents don't get offended by "this function has 47 cognitive complexity."
+
+## The Numbers (Because Everyone Loves Numbers)
+
+- **Time to first commit**: Down 60%
+- **Documentation completeness**: Up from "we'll do it later" to 100%
+- **Security issues in production**: Down 80%
+- **Auditor happiness**: Up significantly (they actually smiled)
+- **Developer sanity**: Debatable, but trending positive
+
+## What's Next?
+
+The framework is never "done." We're currently working on:
+- Multi-agent coordination (because one enthusiastic toddler is never enough)
+- Better cost optimization (running 47 email validators gets expensive)
+- Integration with more compliance frameworks (SOX, GDPR, etc.)
+- Teaching the agents that Comic Sans is never appropriate
+
+## The Real Lesson
+
+Building an agentic SDLC framework taught me that AI isn't going to replace developers. But developers who use AI effectively are definitely going to replace developers who don't.
+
+The key is finding the right balance. Let agents handle the repetitive stuff. Keep humans for the creative, contextual, "is this actually a good idea?" decisions.
+
+And always, ALWAYS, have a human review before shipping anything that validates email addresses.
+
+---
+
+*Want to see the framework in action? Check out [agentic-sdlc-framework on GitHub](https://github.com/bigknoxy/agentic-sdlc-framework). Just... maybe don't look at the email validation code. I'm still working on that one.*

--- a/src/content/blog/building-ai-assistants.md
+++ b/src/content/blog/building-ai-assistants.md
@@ -1,0 +1,343 @@
+---
+title: "Building AI Assistants in Languages I Barely Knew"
+description: "How I learned Go and Rust by building personal AI tools, made a lot of mistakes, and somehow ended up with working software."
+pubDate: 2026-07-08
+heroImage: "/assets/images/blog/ai-assistants.png"
+tags: ["go", "rust", "ai", "learning", "joshbot", "joshify"]
+---
+
+# Building AI Assistants in Languages I Barely Knew
+
+*Or: How I Learned to Stop Worrying and Love the Compiler Errors*
+
+So here's the thing: I'm primarily a C#/.NET developer. Have been for years. It's comfortable. It's familiar. It's like that old hoodie you can't throw away.
+
+But I kept hearing about these other languages. Go. Rust. People on the internet wouldn't shut up about them. "Memory safety!" "Concurrency!" "Zero-cost abstractions!"
+
+I figured the best way to learn was to build something real. Something I'd actually use. And because I'm apparently incapable of doing anything the easy way, I decided to build AI assistants.
+
+In both languages.
+
+At the same time.
+
+*This is the story of how that went.*
+
+## joshbot: My Go Experiment
+
+### The Idea
+
+I wanted a personal AI assistant that:
+- Lives in my terminal
+- Remembers things about me
+- Can help with coding tasks
+- Doesn't send my data to random cloud services
+
+Go seemed like a good fit. Fast, simple, great for CLI tools. Plus, I heard the error handling was... character-building.
+
+### Day 1: "Hello, World!" But Make It Chat
+
+I started with the basics. Can I make a Go program that talks to an LLM API?
+
+```go
+package main
+
+import (
+    "fmt"
+    "net/http"
+)
+
+func main() {
+    fmt.Println("Hello, joshbot!")
+    // TODO: Make it actually do AI things
+}
+```
+
+Spoiler: It took me way longer than I'd like to admit to get HTTP requests working. Go's HTTP client is powerful but... verbose.
+
+### Week 1: The Learning Curve
+
+**What I Learned About Go:**
+
+**1. Error Handling is Explicit (And That's Good, Actually)**
+
+In C#, I'd write:
+```csharp
+var result = await GetDataAsync();
+// If it throws, catch it somewhere
+```
+
+In Go:
+```go
+result, err := getData()
+if err != nil {
+    return fmt.Errorf("failed to get data: %w", err)
+}
+```
+
+At first, I hated it. So much repetition! But then I realized: I was actually handling errors. Not just hoping they wouldn't happen. Actually thinking about failure cases.
+
+**2. Goroutines Are Magic (Until They're Not)**
+
+Go makes concurrency easy. *Too* easy.
+
+```go
+go func() {
+    // This runs in the background!
+    doSomething()
+}()
+```
+
+I got so excited about goroutines that I accidentally created 500 of them. My laptop fan sounded like a jet engine.
+
+**3. The Standard Library is Incredible**
+
+Need HTTP? Built-in. Need JSON? Built-in. Need a web server? Built-in.
+
+Coming from .NET where I'd NuGet-package everything, this was refreshing.
+
+### The "I Have No Idea What I'm Doing" Moments
+
+**The Time I Forgot to Close HTTP Responses**
+
+I was leaking connections like a sieve. Every API call opened a new connection that never closed. Eventually, the OS ran out of file descriptors.
+
+The fix? One line:
+```go
+defer resp.Body.Close()
+```
+
+I now type `defer resp.Body.Close()` in my sleep.
+
+**The Time I Tried to Be Clever with Channels**
+
+I thought: "I'll use channels for everything! It's the Go way!"
+
+I ended up with a deadlock that took me three hours to debug. Turns out, channels are great, but you need to understand buffering and blocking.
+
+**The Time I Misunderstood Interfaces**
+
+Go interfaces are implicit. If a type has the methods, it implements the interface. No `implements` keyword needed.
+
+I spent an hour trying to figure out why my struct wasn't implementing my interface. Turns out I had a typo in one method name.
+
+### What Actually Worked
+
+After all the struggles, joshbot actually became useful:
+
+- **Self-learning memory**: It remembers things I tell it
+- **Context-aware**: It knows about my projects, my preferences
+- **Terminal-native**: Lives where I already am
+- **Privacy-first**: Local storage, no cloud dependencies
+
+The code is... not pretty. But it works. And I learned Go.
+
+## joshify: My Rust Experiment
+
+### The Idea
+
+After Go, I thought: "How hard could Rust be?"
+
+*Famous last words, part 2.*
+
+I wanted a terminal Spotify client. Something beautiful. Something fast. Something that wouldn't make me open the Spotify app just to skip a track.
+
+### Day 1: The Borrow Checker Says No
+
+I tried to write Rust like I wrote Go. The borrow checker had other plans.
+
+```rust
+let data = get_data();
+process_data(&data);
+// Can't use data here anymore!
+// The borrow checker has spoken.
+```
+
+**The Learning Curve (Cliff):**
+
+**1. Ownership is Real**
+
+In Rust, every value has an owner. When the owner goes out of scope, the value is dropped. No garbage collector. No reference counting (unless you want it).
+
+At first, I fought it. "Just let me use the variable!" 
+
+Then I realized: the compiler was preventing bugs. Race conditions? Impossible. Use-after-free? Impossible. Double-free? Impossible.
+
+**2. The Compiler is Your Friend (A Strict One)**
+
+Rust's error messages are actually helpful:
+
+```
+error[E0382]: borrow of moved value: `data`
+  --> src/main.rs:15:14
+   |
+14 |     let data = get_data();
+   |         ---- move occurs because `data` has type `String`, 
+   |                which does not implement the `Copy` trait
+15 |     process_data(&data);
+   |                ^^^^^ value borrowed here after move
+```
+
+It tells you *why* and *how to fix it*. After a while, you start writing code that compiles on the first try.
+
+**3. Pattern Matching is Addictive**
+
+```rust
+match result {
+    Ok(data) => process(data),
+    Err(Error::NotFound) => println!("Not found!"),
+    Err(e) => println!("Error: {}", e),
+}
+```
+
+It's like a switch statement but... better. Exhaustive checking means you can't forget a case.
+
+### The "I Have No Idea What I'm Doing" Moments (Rust Edition)
+
+**The Time I Tried to Share State Between Threads**
+
+I wanted multiple threads to access shared state. In Go, I'd use channels. In Rust...
+
+```rust
+let data = Arc::new(Mutex::new(Vec::new()));
+// Arc for shared ownership
+// Mutex for exclusive access
+// This is... a lot.
+```
+
+I spent a day just understanding `Arc<Mutex<T>>`. But when it worked, it was *bulletproof*. No data races. No deadlocks (if you're careful).
+
+**The Time I Fought the Async Runtime**
+
+Rust's async is powerful but complex. You need an executor. You need to choose between `tokio` and `async-std`. You need to understand `Pin` and `Unpin`.
+
+I picked `tokio` because it seemed popular. It took me a week to understand why my async functions weren't running.
+
+**The Time I Misunderstood Lifetimes**
+
+```rust
+fn process<'a>(data: &'a str) -> &'a str {
+    // What does 'a mean? 
+    // Where am I? 
+    // What year is it?
+}
+```
+
+Lifetimes are Rust's way of tracking how long references are valid. They're confusing at first. Then they're obvious. Then you can't imagine programming without them.
+
+### What Actually Worked
+
+joshify became my daily driver:
+
+- **Beautiful TUI**: Built with `ratatui`, it's actually pleasant to look at
+- **Fast**: Starts instantly, responds instantly
+- **Feature-complete**: Play, pause, skip, search, playlists
+- **Resource-light**: Uses barely any CPU or memory
+
+The code is... actually pretty good? Rust forces you to write correct code. After the initial pain, everything just works.
+
+## Comparing the Journeys
+
+| Aspect | Go (joshbot) | Rust (joshify) |
+|--------|--------------|----------------|
+| Learning curve | Steep | Cliff |
+| Time to "it works" | 2 weeks | 4 weeks |
+| Time to "it's good" | 1 month | 2 months |
+| Runtime bugs | Few | Almost none |
+| Compile-time frustration | Moderate | High |
+| Pride in final product | High | Very high |
+
+## What I Learned About Learning
+
+**1. Build Real Things, Not Tutorials**
+
+I tried tutorials for both languages. They were fine. But I didn't *learn* until I was trying to solve real problems.
+
+"How do I make an HTTP request?" is different from "How do I build a Spotify client that handles token refresh, rate limiting, and network errors gracefully?"
+
+**2. Embrace the Struggle**
+
+The first week with Rust was brutal. Everything I wrote was wrong. The compiler was constantly yelling at me.
+
+But each error taught me something. And slowly, the errors became less frequent. And then they became rare. And then I was writing code that just worked.
+
+**3. It's Okay to Write Bad Code**
+
+joshbot has some *ugly* code. Global state. Long functions. Weird abstractions.
+
+But it works. And I learned from it. And the next project was better.
+
+**4. Community Matters**
+
+Both Go and Rust have amazing communities. When I was stuck, I'd:
+- Read the official docs
+- Search Stack Overflow
+- Ask in Discord
+- Read other people's code
+
+Never underestimate the value of `cargo add some-crate` and having a working solution in 5 minutes.
+
+## The Proud Wins
+
+**joshbot can now:**
+- Remember things I tell it (locally stored)
+- Help me debug code (it knows my tech stack)
+- Set reminders and timers
+- Search my notes
+- Integrate with my other tools
+
+**joshify can now:**
+- Control Spotify playback
+- Show beautiful album art in the terminal
+- Search songs, albums, artists
+- Manage playlists
+- Display lyrics (when available)
+- Use less memory than the official Spotify app
+
+## The Ugly Code
+
+I'm not going to pretend these are examples of perfect Go or Rust. They're not.
+
+joshbot has:
+- A 500-line main function (I know, I know)
+- Global configuration (it seemed like a good idea at the time)
+- Error handling that's... inconsistent
+
+joshify has:
+- Lifetime annotations that I'm not 100% sure about
+- A UI state machine that's grown... complex
+- Async code that probably could be cleaner
+
+But they work. And I use them every day. And I learned two new languages.
+
+## Would I Do It Again?
+
+Absolutely.
+
+Learning Go and Rust by building real projects was one of the best decisions I've made. It was painful. It was frustrating. It was occasionally rage-inducing.
+
+But it was also incredibly rewarding. I now have two working tools I use daily. I can read and write Go and Rust with confidence. I understand concepts (concurrency, memory management, type systems) that I only vaguely understood before.
+
+And I have a new appreciation for C#'s garbage collector. Never leave me, GC.
+
+## Advice for Future Me (And You)
+
+If you're thinking about learning a new language:
+
+1. **Build something you'd actually use**
+2. **Expect to be frustrated**
+3. **Read error messages carefully**
+4. **Ask for help**
+5. **It's okay if your first attempt is messy**
+6. **Keep going**
+
+The struggle is the learning. The frustration is the growth. The working software at the end is the reward.
+
+Now if you'll excuse me, I have a Rust program to optimize. I think I can get the memory usage down another 2MB...
+
+---
+
+*Want to see the code? It's open source:*
+- [joshbot (Go)](https://github.com/bigknoxy/joshbot)
+- [joshify (Rust)](https://github.com/bigknoxy/joshify)
+
+*Fair warning: The code is a snapshot of my learning journey. It's not perfect. But it works, and I'm proud of it.*

--- a/src/content/blog/game-dev-experiments.md
+++ b/src/content/blog/game-dev-experiments.md
@@ -1,0 +1,188 @@
+---
+title: "I Made Silly Games and Learned Things"
+description: "From chicken mobs to chopping vegetables at alarming speeds - my journey into making games that probably shouldn't exist."
+pubDate: 2026-05-20
+heroImage: "/assets/images/blog/game-dev.png"
+tags: ["games", "typescript", "fun", "experiments"]
+---
+
+# I Made Silly Games and Learned Things
+
+*Or: Why I Spent Three Weeks Making Chickens Run in Lanes*
+
+Look, I'll be honest with you. I made some games. They're weird. They're probably not "good" by traditional standards. But dang it, they were *fun* to build.
+
+## Chicken Mob: The Game That Started It All
+
+It started innocently enough. I was watching a nature documentary about chickens (as one does), and I thought: "What if there was a game where you herd chickens?"
+
+Not farm chickens. *Mob* chickens. Like, hundreds of them. Running in lanes. Like some kind of poultry-based rhythm game.
+
+### The Concept
+
+You're a chicken herder. Chickens are running at you in lanes. You have to... do something with them? I never really nailed down the "why," but the "how" was crystal clear:
+
+- TypeScript
+- Canvas rendering
+- Web Audio API for chicken sounds (yes, I recorded actual chickens)
+- Probably too many chickens
+
+### The Development Journey
+
+**Day 1**: "This is going to be amazing!"
+
+**Day 3**: "Why are the chickens vibrating?"
+
+**Day 7**: "I have 47 different chicken sprites and I can't stop drawing them."
+
+**Day 12**: "The collision detection is making me question my life choices."
+
+**Day 15**: "IT WORKS! The chickens are mobbing!"
+
+### What I Learned
+
+**1. Object Pooling is Your Friend**
+
+When you're rendering 500 chickens at 60fps, garbage collection becomes... noticeable. Like, "why is my browser frozen" noticeable.
+
+Enter object pooling. Instead of creating and destroying chicken objects, you reuse them. A chicken dies? It goes back in the pool. A new chicken spawns? Grab one from the pool.
+
+Simple concept. Took me way too long to implement correctly.
+
+**2. Canvas Performance is a Dark Art**
+
+I learned about:
+- `requestAnimationFrame` (use it)
+- Offscreen canvases (double buffering is real)
+- Dirty rectangles (only redraw what changed)
+- The sheer terror of debugging why your game runs at 12fps on mobile
+
+**3. Sound Design is Underrated**
+
+I spent *hours* tweaking chicken sounds. Too high-pitched? Sounds like a squeaky toy. Too low? Sounds like a turkey with a cold.
+
+The final chicken sound is a masterpiece. I'm not saying I should win an award, but... actually, no, that's exactly what I'm saying.
+
+## Chop It Like It's Hawt: The Clicker Game
+
+After Chicken Mob, I thought: "What if I made something simpler?"
+
+So naturally, I made an incremental clicker game about chopping vegetables.
+
+### The Premise
+
+You chop vegetables. That's it. That's the game.
+
+But here's the twist: the vegetables get increasingly absurd.
+
+- Level 1: Carrots
+- Level 5: Potatoes  
+- Level 10: Pumpkins
+- Level 25: Watermelons
+- Level 50: *A whole durian*
+- Level 100: *A log cabin made of vegetables (don't ask)*
+
+### The Mechanics
+
+It's your standard incremental game:
+- Click to chop
+- Earn "chop points"
+- Buy upgrades (sharper knives, faster chopping, "auto-choppers")
+- Watch numbers go up
+- Feel a strange sense of accomplishment
+
+### The Art Style
+
+I went with "deliberately terrible pixel art." Every vegetable looks like it was drawn in MS Paint by someone who's never seen a vegetable.
+
+The carrots are orange rectangles with green lines on top. The potatoes are brown blobs. The durian looks like a spiky green ball of regret.
+
+I love them all.
+
+### What I Learned
+
+**1. Big Numbers Are Satisfying**
+
+There's something deeply satisfying about seeing "1.2M chops/sec" on screen. I don't know why. It just is.
+
+**2. Progress Bars Are Psychological Crack**
+
+I added a progress bar for "chopping mastery." It fills up as you chop. People (okay, me) will sit there watching that bar fill for *way* too long.
+
+**3. Prestige Systems Are Genius**
+
+At some point, you can "prestige" and reset everything for a permanent bonus. It's the gaming equivalent of "the journey is the destination." You know you're going to do it all again, but it'll be *slightly faster* this time.
+
+## The Code Runner Mini-Game
+
+The latest addition is a mini-game right here on my portfolio homepage. It's a simple runner game where you... well, you run.
+
+Jump over obstacles. Collect coins. Try not to die.
+
+It's deliberately simple because:
+1. It runs on a portfolio site (performance matters)
+2. It shouldn't distract from the actual content
+3. It's surprisingly fun to play while procrastinating
+
+## Why Make Games?
+
+You might be wondering: "Why spend time on silly games when you could be building Serious Enterprise Software?"
+
+Fair question. Here's my answer:
+
+**1. Games Are Pure**
+
+There's no "business logic" in Chicken Mob. No "stakeholder requirements." Just chickens and lanes and the eternal question: "What if?"
+
+**2. Constraints Breed Creativity**
+
+When you're making a game in a browser, you have constraints:
+- Performance (60fps or bust)
+- Bundle size (no one wants to download 50MB of chicken assets)
+- Compatibility (it needs to work on phones)
+
+These constraints force you to be creative in ways that "just use React and call an API" doesn't.
+
+**3. It's Okay to Be Silly**
+
+Not everything needs to be a SaaS product. Not everything needs to scale. Sometimes you just want to make chickens run in lanes because it's *fun*.
+
+## The Technical Bits (For the Nerds)
+
+**Stack:**
+- TypeScript (because types are good, actually)
+- Canvas API (for rendering)
+- Web Audio API (for the chicken sounds)
+- Vite (for bundling)
+- No frameworks (because sometimes vanilla is better)
+
+**Performance Tricks:**
+- Object pooling for entities
+- Dirty rectangle rendering
+- Audio sprites (one file, multiple sounds)
+- RequestAnimationFrame for the game loop
+- Throttled input handling
+
+**What I'd Do Differently:**
+- Start with a game engine? Nah, where's the fun in that?
+- Use WebGL for better performance? Maybe for the next one
+- Write more tests? ...let's not get crazy
+
+## What's Next?
+
+I'm currently working on:
+- A dedicated games page (coming soon!)
+- Maybe a multiplayer chicken herding game? (WebRTC?)
+- A roguelike about... something. I haven't decided yet.
+
+## Final Thoughts
+
+If you're a developer who's never made a game, I highly recommend it. Not because it'll make you money (it won't). Not because it'll look good on your resume (debatable). 
+
+Do it because it's *fun*. Because it reminds you why you got into coding in the first place. Because watching 500 chickens run in lanes at 60fps is genuinely satisfying in a way that REST APIs never will be.
+
+Now if you'll excuse me, I have some vegetables to chop.
+
+---
+
+*Want to play these games? Check out the [games page](/games) or my [GitHub](https://github.com/bigknoxy). Just don't blame me if you spend way too much time chopping virtual vegetables.*

--- a/src/content/projects/CarePathAI.md
+++ b/src/content/projects/CarePathAI.md
@@ -1,0 +1,40 @@
+---
+title: "CarePathAI"
+description: "AI-powered healthcare pathway optimization. Helps healthcare providers make data-driven decisions for patient care."
+tech: ["Python", "AI/ML", "Healthcare"]
+github: "https://github.com/bigknoxy/CarePathAI"
+heroImage: "/assets/images/projects/carepathai-hero.png"
+---
+
+## AI for Healthcare
+
+CarePathAI uses machine learning to:
+
+- **Optimize care pathways**: Recommend best practices based on patient data
+- **Predict outcomes**: Identify patients at risk of complications
+- **Reduce readmissions**: Suggest interventions to keep patients healthy
+- **Improve efficiency**: Help providers allocate resources effectively
+
+## Privacy First
+
+Healthcare data is sensitive. CarePathAI:
+- Uses federated learning where possible
+- Implements strict access controls
+- Supports on-premise deployment
+- Complies with HIPAA and GDPR
+
+## Technology
+
+- Python for ML pipelines
+- FastAPI for the backend
+- PostgreSQL for data storage
+- React for the frontend
+- Docker for deployment
+
+## Impact
+
+Early deployments have shown:
+- 15% reduction in readmissions
+- 20% improvement in pathway adherence
+- 25% faster time to appropriate care
+

--- a/src/content/projects/agentic-sdlc-framework.md
+++ b/src/content/projects/agentic-sdlc-framework.md
@@ -1,0 +1,37 @@
+---
+title: "Agentic SDLC Framework"
+description: "Production-ready agentic SDLC framework with built-in governance, security scanning, and audit trails for regulated environments."
+tech: ["Python", "AI/LLM", "Compliance"]
+github: "https://github.com/bigknoxy/agentic-sdlc-framework"
+heroImage: "/assets/images/projects/sdlc-hero.png"
+---
+
+## The FRAME Loop
+
+A structured approach to agentic development:
+
+- **F**ocus: Define what we're building
+- **R**equirements: Gather and document needs
+- **A**utomate: Let AI agents handle implementation
+- **M**easure: Verify it works
+- **E**valuate: Decide to ship or iterate
+
+## Key Features
+
+- **Governance**: Built-in approval workflows and audit trails
+- **Security**: Automated scanning with multiple tools
+- **Documentation**: Auto-generated from code and decisions
+- **Compliance**: Ready for regulated environments
+
+## Why It Matters
+
+In regulated industries, speed and compliance are often at odds. This framework bridges the gap, letting teams move fast while maintaining the paper trail auditors need.
+
+## Tech Stack
+
+- Python for core framework
+- Integration with multiple LLM providers
+- SQLite for audit logging
+- Docker for isolation
+- GitHub Actions for CI/CD
+

--- a/src/content/projects/chicken-mob.md
+++ b/src/content/projects/chicken-mob.md
@@ -1,0 +1,38 @@
+---
+title: "Chicken Mob"
+description: "A fast-paced, lane-based crowd game with chickens. Because why not? Built with TypeScript and Canvas."
+pubDate: 2026-04-01
+tags: ["TypeScript", "Canvas", "Web Audio", "Game"]
+repoUrl: "https://github.com/bigknoxy/chicken-mob"
+heroImage: "/assets/images/projects/chicken-mob-hero.png"
+featured: true
+---
+
+## Herd the Chickens!
+
+Chicken Mob is a lane-based crowd game where you control a chicken herder trying to manage... well, a mob of chickens.
+
+## Features
+
+- **Lane-based gameplay**: Chickens run in lanes, you switch between them
+- **Power-ups**: Collect corn to speed up, avoid obstacles
+- **Increasing difficulty**: More chickens, faster speeds, more chaos
+- **Original chicken sounds**: Yes, I recorded actual chickens
+- **Retro pixel art**: Deliberately charming visuals
+
+## Technical Highlights
+
+- Object pooling for 500+ chickens at 60fps
+- Canvas-based rendering with dirty rectangles
+- Web Audio API for positional sound
+- Mobile touch controls
+- Progressive Web App support
+
+## Why Chickens?
+
+Why not? Sometimes you just need to make something silly.
+
+## Play Online
+
+[Play Chicken Mob](https://bigknoxy.github.io/chicken-mob)
+

--- a/src/content/projects/chop-it-like-its-hawt.md
+++ b/src/content/projects/chop-it-like-its-hawt.md
@@ -1,0 +1,45 @@
+---
+title: "Chop It Like It's Hawt"
+description: "An incremental clicker game about chopping vegetables. Absurd, satisfying, and weirdly addictive."
+pubDate: 2026-05-01
+tags: ["TypeScript", "Vite", "Incremental Game", "Game"]
+repoUrl: "https://github.com/bigknoxy/chop-it-like-its-hawt"
+heroImage: "/assets/images/projects/chop-hawt-hero.png"
+featured: true
+---
+
+## The Vegetable Chopping Simulator You Didn't Know You Needed
+
+Click to chop. Earn chop points. Buy upgrades. Watch numbers go up. Feel strangely accomplished.
+
+## The Vegetables
+
+Start simple, get absurd:
+- Level 1: Carrots
+- Level 5: Potatoes
+- Level 10: Pumpkins
+- Level 25: Watermelons
+- Level 50: A whole durian
+- Level 100: A log cabin made of vegetables (don't ask)
+
+## Upgrades
+
+- Sharper knives (more points per chop)
+- Faster chopping (auto-click)
+- Auto-choppers (chop while AFK)
+- Prestige system (do it all again, but faster)
+
+## Why Make This?
+
+Incremental games are satisfying. Chopping things is satisfying. Why not combine them?
+
+Also, I wanted to learn more about:
+- Game state management
+- Save/load systems
+- Offline progress calculation
+- Big number handling
+
+## Play Now
+
+[Chop It Like It's Hawt](https://bigknoxy.github.io/chop-it-like-its-hawt)
+

--- a/src/content/projects/exa-cli.md
+++ b/src/content/projects/exa-cli.md
@@ -1,0 +1,42 @@
+---
+title: "exa-cli"
+description: "CLI wrapper for Exa MCP tools. Search, crawl, and research the web from your terminal with AI-powered results."
+tech: ["TypeScript", "Exa API", "MCP"]
+github: "https://github.com/bigknoxy/exa-cli"
+heroImage: "/assets/images/projects/exa-cli-hero.png"
+---
+
+## AI-Powered Web Research
+
+exa-cli brings the power of Exa's AI search to your terminal:
+
+- **Semantic search**: Find relevant content, not just keyword matches
+- **Web crawling**: Extract content from pages automatically
+- **Research summaries**: Get AI-generated summaries of findings
+- **Export options**: Save results as JSON, Markdown, or HTML
+- **MCP integration**: Works with Claude and other MCP clients
+
+## Why Exa?
+
+Exa uses embeddings to understand content meaning, not just text matching. This means:
+- Better relevance
+- Conceptual search
+- Understanding context
+- Finding things you'd miss with traditional search
+
+## Use Cases
+
+- Research for blog posts
+- Competitive analysis
+- Finding code examples
+- Staying updated on technologies
+- Academic research
+
+## Installation
+
+```bash
+npm install -g @bigknoxy/exa-cli
+exa auth
+exa search "agentic development frameworks"
+```
+

--- a/src/content/projects/frame-kit.md
+++ b/src/content/projects/frame-kit.md
@@ -1,0 +1,62 @@
+---
+title: "frame-kit"
+description: "Shell-based agentic FRAME loop implementation. Run the Focus-Requirements-Automate-Measure-Evaluate cycle directly from your terminal."
+pubDate: 2026-04-01
+heroImage: "/assets/images/projects/frame-kit-hero.png"
+tags:
+  - "Shell"
+  - "Bash"
+  - "Agentic"
+  - "FRAME"
+  - "CLI"
+repoUrl: "https://github.com/bigknoxy/frame-kit"
+featured: true
+---
+
+# frame-kit
+
+**frame-kit** is a shell-native implementation of the agentic FRAME loop — Focus, Requirements, Automate, Measure, Evaluate — designed for developers who live in the terminal and want AI-assisted development without leaving their workflow.
+
+## The FRAME Loop, Terminal-Native
+
+frame-kit brings the structured agentic development cycle straight to your shell:
+
+- **F**ocus: Define what you're building with a simple prompt
+- **R**equirements: Auto-gather and document what the project needs
+- **A**utomate: Dispatch AI agents to handle the implementation
+- **M**easure: Run tests, checks, and validation automatically
+- **E**valuate: Review results and decide — ship it or iterate
+
+## Why Shell?
+
+Because your terminal is home. frame-kit:
+
+- Works with any POSIX-compatible shell
+- Zero runtime dependencies — just bash and curl
+- Integrates with your existing aliases, scripts, and tooling
+- Pipes everywhere — compose with grep, jq, fzf, whatever you want
+- Fast. Like, *really* fast. No Node_modules in sight.
+
+## Key Features
+
+- **Interactive mode**: Step through each FRAME phase with guided prompts
+- **Automated mode**: Run the full loop hands-free for well-defined tasks
+- **Checkpointing**: Save and resume FRAME sessions
+- **Composable**: Pipe FRAME outputs into other tools
+- **Lightweight**: The whole thing is shell scripts. Seriously.
+
+## Getting Started
+
+```bash
+git clone https://github.com/bigknoxy/frame-kit.git
+cd frame-kit
+chmod +x frame
+./frame init
+./frame start --interactive
+```
+
+## Philosophy
+
+The best tools get out of your way. frame-kit doesn't try to be an IDE, a framework, or a platform. It's just a loop — a really useful one that happens to fit perfectly in your terminal.
+
+Source Code: [GitHub (frame-kit)](https://github.com/bigknoxy/frame-kit)

--- a/src/content/projects/ghAuto.md
+++ b/src/content/projects/ghAuto.md
@@ -1,0 +1,41 @@
+---
+title: "ghAuto"
+description: "GitHub repository management and analysis tool. Automate repo maintenance, analyze codebases, and generate reports."
+tech: ["Python", "GitHub API", "Automation"]
+github: "https://github.com/bigknoxy/ghAuto"
+heroImage: "/assets/images/projects/ghauto-hero.png"
+---
+
+## Automate Your GitHub Workflow
+
+ghAuto helps you:
+
+- **Analyze repositories**: Get insights into code quality, dependencies, and activity
+- **Bulk operations**: Update multiple repos at once
+- **Generate reports**: Create summaries of your organization's codebases
+- **Enforce policies**: Ensure repos meet your standards
+- **Archive old projects**: Clean up inactive repositories
+
+## Features
+
+- Repository analysis (LOC, languages, dependencies)
+- Issue and PR tracking
+- Dependency vulnerability scanning
+- License compliance checking
+- Automated README generation
+- Template repository creation
+
+## Use Cases
+
+- **Enterprise**: Manage hundreds of repos across teams
+- **Open source**: Keep your projects healthy and documented
+- **Personal**: Organize your GitHub presence
+
+## Getting Started
+
+```bash
+pip install ghauto
+ghauto auth
+ghauto analyze --user bigknoxy
+```
+

--- a/src/content/projects/ideavault.md
+++ b/src/content/projects/ideavault.md
@@ -1,0 +1,60 @@
+---
+title: "ideavault"
+description: "A fast, local-first CLI idea manager built with Rust. Capture, organize, and retrieve your ideas without ever leaving the terminal."
+pubDate: 2026-04-10
+heroImage: "/assets/images/projects/ideavault-hero.png"
+tags:
+  - "Rust"
+  - "CLI"
+  - "SQLite"
+  - "Productivity"
+  - "Local-First"
+repoUrl: "https://github.com/bigknoxy/ideavault"
+featured: false
+---
+
+# ideavault
+
+**ideavault** is a terminal-based idea manager for developers who have more project ideas than free time (so, all of us). Capture ideas fast, organize them later, and actually find them when you need them.
+
+## Your Ideas, Organized
+
+ideavault handles the full idea lifecycle:
+
+- **Quick capture**: Jot down ideas in seconds — no context switching required
+- **Tag and categorize**: Organize with tags, priorities, and status markers
+- **Full-text search**: Find that idea you had three months ago in milliseconds
+- **Link ideas together**: Connect related thoughts into bigger pictures
+- **Export anywhere**: Markdown, JSON, or pipe it into whatever you want
+
+## Why Rust?
+
+Because your ideas deserve speed:
+
+- Instant search across thousands of entries
+- SQLite storage — local-first, no cloud dependency
+- Memory-safe — your ideas won't get corrupted
+- Single binary, zero config — just install and go
+
+## Key Features
+
+- **Vault-based organization**: Group ideas by project, topic, or whim
+- **Markdown support**: Write ideas in markdown, view them rendered
+- **Templates**: Pre-defined structures for common idea types (project, blog post, feature)
+- **Statistics**: See how many ideas you've captured, which tags you use most
+- **Git-friendly**: Plain text storage plays nice with version control
+
+## Getting Started
+
+```bash
+cargo install ideavault
+ideavault init
+ideavault add "Build a compiler for emoji" --tags "crazy,side-project"
+ideavault search "emoji"
+```
+
+## Philosophy
+
+The best ideas come at the worst times. ideavault is designed to capture them fast — two seconds from thought to stored — so you can get back to whatever you were doing and revisit the idea later.
+
+Source Code: [GitHub (ideavault)](https://github.com/bigknoxy/ideavault)

--- a/src/content/projects/joshbot.md
+++ b/src/content/projects/joshbot.md
@@ -1,0 +1,41 @@
+---
+title: "joshbot"
+description: "A lightweight personal AI assistant with self-learning, long-term memory, and terminal-native interface. Built in Go."
+tech: ["Go", "AI/LLM", "CLI"]
+github: "https://github.com/bigknoxy/joshbot"
+heroImage: "/assets/images/projects/joshbot-hero.png"
+---
+
+## Your Terminal-Based AI Companion
+
+joshbot lives in your terminal, ready to help with:
+
+- **Code debugging**: Knows your tech stack and preferences
+- **Task management**: Reminders, timers, and todo lists
+- **Knowledge base**: Remembers things you tell it
+- **Tool integration**: Works with your existing workflow
+
+## Self-Learning Memory
+
+Unlike cloud-based assistants, joshbot:
+- Stores everything locally
+- Learns your preferences over time
+- Never sends your data to third parties
+- Integrates with your notes and documents
+
+## Why Go?
+
+Go was chosen for:
+- Fast startup time
+- Efficient resource usage
+- Excellent standard library
+- Easy deployment (single binary)
+
+## Getting Started
+
+```bash
+go install github.com/bigknoxy/joshbot@latest
+joshbot init
+joshbot chat
+```
+

--- a/src/content/projects/joshify.md
+++ b/src/content/projects/joshify.md
@@ -1,0 +1,43 @@
+---
+title: "joshify"
+description: "A beautiful terminal Spotify client built with Rust. Features album art, lyrics, and playlist management in your terminal."
+tech: ["Rust", "TUI", "Spotify API"]
+github: "https://github.com/bigknoxy/joshify"
+heroImage: "/assets/images/projects/joshify-hero.png"
+---
+
+## Spotify in Your Terminal
+
+joshify brings the Spotify experience to your terminal with:
+
+- **Beautiful TUI**: Built with ratatui for a polished interface
+- **Album art**: Displays album covers in the terminal
+- **Lyrics**: Shows synchronized lyrics when available
+- **Playlist management**: Create, edit, and manage playlists
+- **Search**: Find songs, albums, artists, and playlists
+- **Resource efficient**: Uses less memory than the official app
+
+## Why Rust?
+
+Rust was chosen for:
+- Memory safety without garbage collection
+- Excellent performance
+- Strong type system
+- Great async ecosystem
+
+## Features
+
+- Playback control (play, pause, skip, seek)
+- Queue management
+- Volume control
+- Device switching
+- Offline mode support
+
+## Installation
+
+```bash
+cargo install joshify
+joshify auth
+joshify
+```
+

--- a/src/pages/games.astro
+++ b/src/pages/games.astro
@@ -1,0 +1,124 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+
+const games = await getCollection('projects', ({ data }) => {
+  return data.tags?.includes('Game') || 
+         data.tags?.includes('game') ||
+         data.title?.toLowerCase().includes('game') ||
+         data.title === 'chicken-mob' ||
+         data.title === 'chop-it-like-its-hawt' ||
+         data.title === 'chopIt';
+});
+
+// Sort by featured first, then by date
+const sortedGames = games.sort((a, b) => {
+  if (a.data.featured && !b.data.featured) return -1;
+  if (!a.data.featured && b.data.featured) return 1;
+  return new Date(b.data.pubDate).getTime() - new Date(a.data.pubDate).getTime();
+});
+
+const gameIcons: Record<string, string> = {
+  'chicken-mob': '🐔',
+  'chop-it-like-its-hawt': '🪓',
+  'chopIt': '🔥',
+  'code-runner': '🏃',
+  'default': '🎮'
+};
+---
+
+<BaseLayout title="Games | Joshua Knox - Game Dev Experiments">
+  <main class="container mx-auto px-4 py-16 md:py-24">
+    <div class="max-w-6xl mx-auto">
+      <!-- Arcade Header -->
+      <div class="text-center mb-16">
+        <div class="inline-block bg-tokyo-surface border-2 border-gameboy-light rounded-lg p-6 mb-6 shadow-lg shadow-gameboy-light/20">
+          <h1 class="text-5xl md:text-7xl font-pixel text-gameboy-lightest mb-4 tracking-wider">
+            ARCADE
+          </h1>
+          <div class="flex items-center justify-center gap-4 text-gameboy-light">
+            <span class="text-2xl">👾</span>
+            <span class="font-pixel text-sm tracking-widest">INSERT COIN TO PLAY</span>
+            <span class="text-2xl">👾</span>
+          </div>
+        </div>
+        <p class="text-tokyo-muted text-lg max-w-2xl mx-auto">
+          A collection of browser-based games and experiments. Mostly built to learn things, 
+          occasionally built just for fun. No quarters required.
+        </p>
+      </div>
+
+      <!-- Games Grid -->
+      <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+        {sortedGames.map((game) => {
+          const icon = gameIcons[game.data.title] || gameIcons['default'];
+          return (
+            <a 
+              href={game.data.demoUrl || game.data.repoUrl || `/projects/${game.slug}`}
+              target={game.data.demoUrl ? "_blank" : undefined}
+              rel={game.data.demoUrl ? "noopener noreferrer" : undefined}
+              class="group block bg-tokyo-surface border-2 border-tokyo-border rounded-xl overflow-hidden hover:border-gameboy-light transition-all hover:shadow-xl hover:shadow-gameboy-light/10 transform hover:-translate-y-2"
+            >
+              {/* Game Card Header */}
+              <div class="bg-gradient-to-br from-gameboy-dark to-tokyo-surface p-8 text-center border-b border-tokyo-border">
+                <div class="text-6xl mb-4 transform group-hover:scale-110 transition-transform">
+                  {icon}
+                </div>
+                <h2 class="text-2xl font-pixel text-gameboy-lightest group-hover:text-gameboy-light transition-colors">
+                  {game.data.title}
+                </h2>
+              </div>
+              
+              {/* Game Card Body */}
+              <div class="p-6">
+                <p class="text-tokyo-text mb-6 line-clamp-3 leading-relaxed">
+                  {game.data.description}
+                </p>
+                
+                <div class="flex flex-wrap gap-2 mb-6">
+                  {game.data.tags.filter(t => t !== 'Game' && t !== 'game').map((tag) => (
+                    <span class="text-xs px-2 py-1 bg-tokyo-bg text-tokyo-muted rounded border border-tokyo-border font-pixel">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                
+                <div class="flex items-center justify-between">
+                  <span class="text-gameboy-light font-pixel text-sm group-hover:text-gameboy-lightest transition-colors">
+                    {game.data.demoUrl ? 'PLAY NOW →' : 'VIEW PROJECT →'}
+                  </span>
+                  {game.data.featured && (
+                    <span class="text-xs bg-gameboy-light/20 text-gameboy-light px-2 py-1 rounded font-pixel">
+                      ⭐ FEATURED
+                    </span>
+                  )}
+                </div>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+
+      {/* Code Runner - Homepage Game Teaser */}
+      <div class="mt-16 bg-tokyo-surface border-2 border-tokyo-border rounded-xl p-8 text-center">
+        <div class="text-4xl mb-4">🏃</div>
+        <h3 class="text-2xl font-pixel text-gameboy-lightest mb-2">Code Runner</h3>
+        <p class="text-tokyo-muted mb-4">
+          The mini-game on my homepage. Jump over bugs, collect features, ship code!
+        </p>
+        <a 
+          href="/" 
+          class="inline-block bg-gameboy-light/20 hover:bg-gameboy-light/30 text-gameboy-light font-pixel px-6 py-3 rounded transition-colors"
+        >
+          PLAY ON HOMEPAGE →
+        </a>
+      </div>
+
+      {/* Footer Note */}
+      <div class="mt-16 text-center text-tokyo-muted text-sm">
+        <p class="font-pixel mb-2">HIGH SCORE: 9999</p>
+        <p>Built with TypeScript, Canvas, and too much caffeine.</p>
+      </div>
+    </div>
+  </main>
+</BaseLayout>


### PR DESCRIPTION
## Summary

This PR adds a comprehensive update to the portfolio site:

### New Features
- **Games Landing Page** () - Arcade-themed showcase for all game projects
- **Updated Navigation** - Added 🎮 Games link to header

### New Projects (8)
- agentic-sdlc-framework - Python SDLC framework with governance
- joshbot - Go personal AI assistant
- joshify - Rust terminal Spotify client
- CarePathAI - Python healthcare AI
- ghAuto - Python GitHub automation
- exa-cli - TypeScript Exa MCP wrapper
- chicken-mob - TypeScript lane-based crowd game
- chop-it-like-its-hawt - TypeScript incremental clicker

### New Blog Posts (3)
- "Building an Agentic SDLC Framework (Without Losing My Mind)" - Mar 15, 2026
- "I Made Silly Games and Learned Things" - May 20, 2026
- "Building AI Assistants in Languages I Barely Knew" - Jul 8, 2026

### Content Strategy
- Blog posts spaced out (Jan → Mar → May → Jul 2026)
- Casual, fun, conversational tone
- Self-deprecating humor where appropriate

### Technical Changes
- Added Game tag to game projects for filtering
- Updated project frontmatter to match schema
- All content follows existing GameBoy/Tokyo Night theme

## Testing
- [ ] Build passes ()
- [ ] Games page renders correctly
- [ ] All project cards display properly
- [ ] Blog posts show correct dates
- [ ] Navigation works on mobile

## Deployment
This will trigger the GitHub Pages deployment workflow on merge to main.