### PR TITLE
fix: Correct frontmatter schema for project files

### DIFF
--- a/src/content/projects/CarePathAI.md
+++ b/src/content/projects/CarePathAI.md
@@ -1,9 +1,12 @@
+featured: false
 ---
 title: "CarePathAI"
 description: "AI-powered healthcare pathway optimization. Helps healthcare providers make data-driven decisions for patient care."
-tech: ["Python", "AI/ML", "Healthcare"]
-github: "https://github.com/bigknoxy/CarePathAI"
+tags: ["Python", "AI/ML", "Healthcare"]
+repoUrl: "https://github.com/bigknoxy/CarePathAI"
+pubDate: 2026-04-01
 heroImage: "/assets/images/projects/carepathai-hero.png"
+featured: false
 ---
 
 ## AI for Healthcare

--- a/src/content/projects/agentic-sdlc-framework.md
+++ b/src/content/projects/agentic-sdlc-framework.md
@@ -1,9 +1,12 @@
+featured: false
 ---
 title: "Agentic SDLC Framework"
 description: "Production-ready agentic SDLC framework with built-in governance, security scanning, and audit trails for regulated environments."
-tech: ["Python", "AI/LLM", "Compliance"]
-github: "https://github.com/bigknoxy/agentic-sdlc-framework"
+tags: ["Python", "AI/LLM", "Compliance"]
+repoUrl: "https://github.com/bigknoxy/agentic-sdlc-framework"
+pubDate: 2026-04-01
 heroImage: "/assets/images/projects/sdlc-hero.png"
+featured: false
 ---
 
 ## The FRAME Loop

--- a/src/content/projects/exa-cli.md
+++ b/src/content/projects/exa-cli.md
@@ -1,9 +1,12 @@
+featured: false
 ---
 title: "exa-cli"
 description: "CLI wrapper for Exa MCP tools. Search, crawl, and research the web from your terminal with AI-powered results."
-tech: ["TypeScript", "Exa API", "MCP"]
-github: "https://github.com/bigknoxy/exa-cli"
+tags: ["TypeScript", "Exa API", "MCP"]
+repoUrl: "https://github.com/bigknoxy/exa-cli"
+pubDate: 2026-04-01
 heroImage: "/assets/images/projects/exa-cli-hero.png"
+featured: false
 ---
 
 ## AI-Powered Web Research

--- a/src/content/projects/ghAuto.md
+++ b/src/content/projects/ghAuto.md
@@ -1,9 +1,12 @@
+featured: false
 ---
 title: "ghAuto"
 description: "GitHub repository management and analysis tool. Automate repo maintenance, analyze codebases, and generate reports."
-tech: ["Python", "GitHub API", "Automation"]
-github: "https://github.com/bigknoxy/ghAuto"
+tags: ["Python", "GitHub API", "Automation"]
+repoUrl: "https://github.com/bigknoxy/ghAuto"
+pubDate: 2026-04-01
 heroImage: "/assets/images/projects/ghauto-hero.png"
+featured: false
 ---
 
 ## Automate Your GitHub Workflow

--- a/src/content/projects/joshbot.md
+++ b/src/content/projects/joshbot.md
@@ -1,9 +1,11 @@
 ---
 title: "joshbot"
 description: "A lightweight personal AI assistant with self-learning, long-term memory, and terminal-native interface. Built in Go."
-tech: ["Go", "AI/LLM", "CLI"]
-github: "https://github.com/bigknoxy/joshbot"
+pubDate: 2026-04-15
+tags: ["Go", "AI/LLM", "CLI"]
+repoUrl: "https://github.com/bigknoxy/joshbot"
 heroImage: "/assets/images/projects/joshbot-hero.png"
+featured: false
 ---
 
 ## Your Terminal-Based AI Companion

--- a/src/content/projects/joshify.md
+++ b/src/content/projects/joshify.md
@@ -1,9 +1,12 @@
+featured: false
 ---
 title: "joshify"
 description: "A beautiful terminal Spotify client built with Rust. Features album art, lyrics, and playlist management in your terminal."
-tech: ["Rust", "TUI", "Spotify API"]
-github: "https://github.com/bigknoxy/joshify"
+tags: ["Rust", "TUI", "Spotify API"]
+repoUrl: "https://github.com/bigknoxy/joshify"
+pubDate: 2026-04-01
 heroImage: "/assets/images/projects/joshify-hero.png"
+featured: false
 ---
 
 ## Spotify in Your Terminal


### PR DESCRIPTION
## Problem
Build failed due to schema validation errors in project content files.

## Changes
- Changed 'tech:' to 'tags:' (Astro content collection expects 'tags')
- Changed 'github:' to 'repoUrl:' (matches schema definition)
- Added missing 'pubDate' field
- Added missing 'featured' field

## Files Fixed
- CarePathAI.md
- agentic-sdlc-framework.md
- exa-cli.md
- ghAuto.md
- joshbot.md
- joshify.md

## Verification
- [ ] CI/CD passes
- [ ] Site deploys successfully
- [ ] Projects page renders correctly