### PR TITLE
fix: Add null safety to games.astro

### DIFF
--- a/src/pages/games.astro
+++ b/src/pages/games.astro
@@ -3,12 +3,14 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 
 const games = await getCollection('projects', ({ data }) => {
-  return data.tags?.includes('Game') || 
-         data.tags?.includes('game') ||
-         data.title?.toLowerCase().includes('game') ||
-         data.title === 'chicken-mob' ||
-         data.title === 'chop-it-like-its-hawt' ||
-         data.title === 'chopIt';
+  const tags = data.tags || [];
+  const title = data.title || '';
+  return tags.includes('Game') || 
+         tags.includes('game') ||
+         title.toLowerCase().includes('game') ||
+         title === 'chicken-mob' ||
+         title === 'chop-it-like-its-hawt' ||
+         title === 'chopIt';
 });
 
 // Sort by featured first, then by date


### PR DESCRIPTION
## Problem
Build failing potentially due to TypeScript null checking in games.astro filter.

## Changes
- Add null safety for tags and title properties
- Handle cases where data.tags or data.title might be undefined

## Verification
- [ ] CI/CD passes
- [ ] Site deploys successfully