### PR TITLE
fix: Correct import path in games.astro

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "bigknoxy-portfolio",

--- a/src/pages/games.astro
+++ b/src/pages/games.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 
 const games = await getCollection('projects', ({ data }) => {


### PR DESCRIPTION
## Problem
Build failing with:
```
Could not resolve "../../layouts/BaseLayout.astro" from "src/pages/games.astro"
```

## Root Cause
Import path was incorrect - games.astro is in `src/pages/` so the relative path should be `../layouts/` not `../../layouts/`.

## Fix
Changed import from `../../layouts/BaseLayout.astro` to `../layouts/BaseLayout.astro`.

## Verification
- [x] Build passes locally (`bun run build`)
- [x] 21 pages generated successfully
- [x] Pagefind indexed successfully

Fixes broken builds #24-28