### PR TITLE
fix: Add placeholder hero images for projects

### DIFF
--- a/public/assets/images/projects/carepathai-hero.svg
+++ b/public/assets/images/projects/carepathai-hero.svg
@@ -1,0 +1,10 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#1a1b26"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#24283b" rx="20"/>
+  <text x="600" y="315" font-family="monospace" font-size="48" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    Carepathai
+  </text>
+  <text x="600" y="380" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Project Preview
+  </text>
+</svg>

--- a/public/assets/images/projects/chicken-mob-hero.svg
+++ b/public/assets/images/projects/chicken-mob-hero.svg
@@ -1,0 +1,10 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#1a1b26"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#24283b" rx="20"/>
+  <text x="600" y="315" font-family="monospace" font-size="48" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    Chicken Mob
+  </text>
+  <text x="600" y="380" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Project Preview
+  </text>
+</svg>

--- a/public/assets/images/projects/chop-hawt-hero.svg
+++ b/public/assets/images/projects/chop-hawt-hero.svg
@@ -1,0 +1,10 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#1a1b26"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#24283b" rx="20"/>
+  <text x="600" y="315" font-family="monospace" font-size="48" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    Chop Hawt
+  </text>
+  <text x="600" y="380" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Project Preview
+  </text>
+</svg>

--- a/public/assets/images/projects/exa-cli-hero.svg
+++ b/public/assets/images/projects/exa-cli-hero.svg
@@ -1,0 +1,10 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#1a1b26"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#24283b" rx="20"/>
+  <text x="600" y="315" font-family="monospace" font-size="48" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    Exa Cli
+  </text>
+  <text x="600" y="380" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Project Preview
+  </text>
+</svg>

--- a/public/assets/images/projects/frame-kit-hero.svg
+++ b/public/assets/images/projects/frame-kit-hero.svg
@@ -1,0 +1,10 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#1a1b26"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#24283b" rx="20"/>
+  <text x="600" y="315" font-family="monospace" font-size="48" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    Frame Kit
+  </text>
+  <text x="600" y="380" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Project Preview
+  </text>
+</svg>

--- a/public/assets/images/projects/ghauto-hero.svg
+++ b/public/assets/images/projects/ghauto-hero.svg
@@ -1,0 +1,10 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#1a1b26"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#24283b" rx="20"/>
+  <text x="600" y="315" font-family="monospace" font-size="48" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    Ghauto
+  </text>
+  <text x="600" y="380" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Project Preview
+  </text>
+</svg>

--- a/public/assets/images/projects/ideavault-hero.svg
+++ b/public/assets/images/projects/ideavault-hero.svg
@@ -1,0 +1,10 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#1a1b26"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#24283b" rx="20"/>
+  <text x="600" y="315" font-family="monospace" font-size="48" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    Ideavault
+  </text>
+  <text x="600" y="380" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Project Preview
+  </text>
+</svg>

--- a/public/assets/images/projects/joshbot-hero.svg
+++ b/public/assets/images/projects/joshbot-hero.svg
@@ -1,0 +1,10 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#1a1b26"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#24283b" rx="20"/>
+  <text x="600" y="315" font-family="monospace" font-size="48" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    Joshbot
+  </text>
+  <text x="600" y="380" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Project Preview
+  </text>
+</svg>

--- a/public/assets/images/projects/joshify-hero.svg
+++ b/public/assets/images/projects/joshify-hero.svg
@@ -1,0 +1,10 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#1a1b26"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#24283b" rx="20"/>
+  <text x="600" y="315" font-family="monospace" font-size="48" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    Joshify
+  </text>
+  <text x="600" y="380" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Project Preview
+  </text>
+</svg>

--- a/public/assets/images/projects/sdlc-hero.svg
+++ b/public/assets/images/projects/sdlc-hero.svg
@@ -1,0 +1,10 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#1a1b26"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#24283b" rx="20"/>
+  <text x="600" y="315" font-family="monospace" font-size="48" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    Sdlc
+  </text>
+  <text x="600" y="380" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Project Preview
+  </text>
+</svg>

--- a/src/content/projects/CarePathAI.md
+++ b/src/content/projects/CarePathAI.md
@@ -4,7 +4,7 @@ description: "AI-powered healthcare pathway optimization. Helps healthcare provi
 pubDate: 2026-04-01
 tags: ["Python", "AI/ML", "Healthcare"]
 repoUrl: "https://github.com/bigknoxy/CarePathAI"
-heroImage: "/assets/images/projects/carepathai-hero.png"
+heroImage: "/assets/images/projects/carepathai-hero.svg"
 featured: false
 ---
 

--- a/src/content/projects/agentic-sdlc-framework.md
+++ b/src/content/projects/agentic-sdlc-framework.md
@@ -4,7 +4,7 @@ description: "Production-ready agentic SDLC framework with built-in governance, 
 pubDate: 2026-04-01
 tags: ["Python", "AI/LLM", "Compliance"]
 repoUrl: "https://github.com/bigknoxy/agentic-sdlc-framework"
-heroImage: "/assets/images/projects/sdlc-hero.png"
+heroImage: "/assets/images/projects/sdlc-hero.svg"
 featured: false
 ---
 

--- a/src/content/projects/chicken-mob.md
+++ b/src/content/projects/chicken-mob.md
@@ -4,7 +4,7 @@ description: "A fast-paced, lane-based crowd game with chickens. Because why not
 pubDate: 2026-04-01
 tags: ["TypeScript", "Canvas", "Web Audio", "Game"]
 repoUrl: "https://github.com/bigknoxy/chicken-mob"
-heroImage: "/assets/images/projects/chicken-mob-hero.png"
+heroImage: "/assets/images/projects/chicken-mob-hero.svg"
 featured: true
 ---
 

--- a/src/content/projects/chop-it-like-its-hawt.md
+++ b/src/content/projects/chop-it-like-its-hawt.md
@@ -4,7 +4,7 @@ description: "An incremental clicker game about chopping vegetables. Absurd, sat
 pubDate: 2026-05-01
 tags: ["TypeScript", "Vite", "Incremental Game", "Game"]
 repoUrl: "https://github.com/bigknoxy/chop-it-like-its-hawt"
-heroImage: "/assets/images/projects/chop-hawt-hero.png"
+heroImage: "/assets/images/projects/chop-hawt-hero.svg"
 featured: true
 ---
 

--- a/src/content/projects/exa-cli.md
+++ b/src/content/projects/exa-cli.md
@@ -4,7 +4,7 @@ description: "CLI wrapper for Exa MCP tools. Search, crawl, and research the web
 pubDate: 2026-04-01
 tags: ["TypeScript", "Exa API", "MCP"]
 repoUrl: "https://github.com/bigknoxy/exa-cli"
-heroImage: "/assets/images/projects/exa-cli-hero.png"
+heroImage: "/assets/images/projects/exa-cli-hero.svg"
 featured: false
 ---
 

--- a/src/content/projects/frame-kit.md
+++ b/src/content/projects/frame-kit.md
@@ -2,7 +2,7 @@
 title: "frame-kit"
 description: "Shell-based agentic FRAME loop implementation. Run the Focus-Requirements-Automate-Measure-Evaluate cycle directly from your terminal."
 pubDate: 2026-04-01
-heroImage: "/assets/images/projects/frame-kit-hero.png"
+heroImage: "/assets/images/projects/frame-kit-hero.svg"
 tags:
   - "Shell"
   - "Bash"

--- a/src/content/projects/ghAuto.md
+++ b/src/content/projects/ghAuto.md
@@ -4,7 +4,7 @@ description: "GitHub repository management and analysis tool. Automate repo main
 pubDate: 2026-04-01
 tags: ["Python", "GitHub API", "Automation"]
 repoUrl: "https://github.com/bigknoxy/ghAuto"
-heroImage: "/assets/images/projects/ghauto-hero.png"
+heroImage: "/assets/images/projects/ghauto-hero.svg"
 featured: false
 ---
 

--- a/src/content/projects/ideavault.md
+++ b/src/content/projects/ideavault.md
@@ -2,7 +2,7 @@
 title: "ideavault"
 description: "A fast, local-first CLI idea manager built with Rust. Capture, organize, and retrieve your ideas without ever leaving the terminal."
 pubDate: 2026-04-10
-heroImage: "/assets/images/projects/ideavault-hero.png"
+heroImage: "/assets/images/projects/ideavault-hero.svg"
 tags:
   - "Rust"
   - "CLI"

--- a/src/content/projects/jeetSocial.md
+++ b/src/content/projects/jeetSocial.md
@@ -2,7 +2,7 @@
 title: "JeetSocial"
 description: "A safe, anonymous social network dedicated to spreading kindness and positivity. Just 'yeet' some good vibes into the universe!"
 pubDate: 2026-01-15
-heroImage: "/assets/images/projects/jeetsocial/hero-new.png"
+heroImage: "/assets/images/projects/jeetsocial/hero-new.svg"
 tags:
   - "Bun"
   - "Hono"

--- a/src/content/projects/joshbot.md
+++ b/src/content/projects/joshbot.md
@@ -4,7 +4,7 @@ description: "A lightweight personal AI assistant with self-learning, long-term 
 pubDate: 2026-04-15
 tags: ["Go", "AI/LLM", "CLI"]
 repoUrl: "https://github.com/bigknoxy/joshbot"
-heroImage: "/assets/images/projects/joshbot-hero.png"
+heroImage: "/assets/images/projects/joshbot-hero.svg"
 featured: false
 ---
 

--- a/src/content/projects/joshify.md
+++ b/src/content/projects/joshify.md
@@ -4,7 +4,7 @@ description: "A beautiful terminal Spotify client built with Rust. Features albu
 pubDate: 2026-04-01
 tags: ["Rust", "TUI", "Spotify API"]
 repoUrl: "https://github.com/bigknoxy/joshify"
-heroImage: "/assets/images/projects/joshify-hero.png"
+heroImage: "/assets/images/projects/joshify-hero.svg"
 featured: false
 ---
 

--- a/src/content/projects/sqlOptimizer.md
+++ b/src/content/projects/sqlOptimizer.md
@@ -2,7 +2,7 @@
 title: "SQL Optimizer Pro"
 description: "AI-powered SQL query optimization tool that transforms suboptimal queries into production-ready code using LLMs."
 pubDate: 2026-01-15
-heroImage: "/assets/images/projects/sqloptimizer/screenshot.png"
+heroImage: "/assets/images/projects/sqloptimizer/screenshot.svg"
 tags:
   - "SQL"
   - "AI"


### PR DESCRIPTION
## Problem
404 errors for missing project hero images:
- chicken-mob-hero.png
- chop-hawt-hero.png
- frame-kit-hero.png
- etc.

## Solution
- Created SVG placeholder images for 10 projects
- Updated all project files to reference .svg instead of .png
- SVGs are lightweight and match the GameBoy/Tokyo Night theme

## Files Changed
- 10 new SVG placeholder images
- 12 project markdown files updated

## Verification
- [ ] Build passes
- [ ] Project pages load without 404s
- [ ] Images display correctly