### PR TITLE
feat: Add 4 missing games to portfolio

### DIFF
--- a/public/assets/images/projects/pew-run-hero.svg
+++ b/public/assets/images/projects/pew-run-hero.svg
@@ -1,0 +1,19 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1b26"/>
+      <stop offset="100%" style="stop-color:#24283b"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#1f2335" rx="20" opacity="0.5"/>
+  <text x="600" y="280" font-family="monospace" font-size="120" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    🚀
+  </text>
+  <text x="600" y="420" font-family="monospace" font-size="48" fill="#c0caf5" text-anchor="middle" dominant-baseline="middle">
+    Pew Run
+  </text>
+  <text x="600" y="480" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Game Project
+  </text>
+</svg>

--- a/public/assets/images/projects/smashmine-hero.svg
+++ b/public/assets/images/projects/smashmine-hero.svg
@@ -1,0 +1,19 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1b26"/>
+      <stop offset="100%" style="stop-color:#24283b"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#1f2335" rx="20" opacity="0.5"/>
+  <text x="600" y="280" font-family="monospace" font-size="120" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    💎
+  </text>
+  <text x="600" y="420" font-family="monospace" font-size="48" fill="#c0caf5" text-anchor="middle" dominant-baseline="middle">
+    SmashMine
+  </text>
+  <text x="600" y="480" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Game Project
+  </text>
+</svg>

--- a/public/assets/images/projects/tiny-fixers-hero.svg
+++ b/public/assets/images/projects/tiny-fixers-hero.svg
@@ -1,0 +1,19 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1b26"/>
+      <stop offset="100%" style="stop-color:#24283b"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#1f2335" rx="20" opacity="0.5"/>
+  <text x="600" y="280" font-family="monospace" font-size="120" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    🔧
+  </text>
+  <text x="600" y="420" font-family="monospace" font-size="48" fill="#c0caf5" text-anchor="middle" dominant-baseline="middle">
+    Tiny Fixers
+  </text>
+  <text x="600" y="480" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Game Project
+  </text>
+</svg>

--- a/public/assets/images/projects/toilet-runner-hero.svg
+++ b/public/assets/images/projects/toilet-runner-hero.svg
@@ -1,0 +1,19 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1b26"/>
+      <stop offset="100%" style="stop-color:#24283b"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="50" y="50" width="1100" height="530" fill="#1f2335" rx="20" opacity="0.5"/>
+  <text x="600" y="280" font-family="monospace" font-size="120" fill="#7aa2f7" text-anchor="middle" dominant-baseline="middle">
+    🧻
+  </text>
+  <text x="600" y="420" font-family="monospace" font-size="48" fill="#c0caf5" text-anchor="middle" dominant-baseline="middle">
+    Toilet Runner
+  </text>
+  <text x="600" y="480" font-family="monospace" font-size="24" fill="#565f89" text-anchor="middle" dominant-baseline="middle">
+    Game Project
+  </text>
+</svg>

--- a/src/content/projects/pew-run-game.md
+++ b/src/content/projects/pew-run-game.md
@@ -1,0 +1,37 @@
+---
+title: "Pew Run"
+description: "Fast-paced space shooter PWA — dodge, shoot, and survive waves of enemies and bosses. Built with vanilla JS and Canvas, no frameworks."
+pubDate: 2026-02-13
+heroImage: "/assets/images/projects/pew-run-hero.svg"
+tags:
+  - "JavaScript"
+  - "Canvas"
+  - "Space Shooter"
+  - "Game"
+  - "PWA"
+repoUrl: "https://github.com/bigknoxy/pew-run-game"
+featured: true
+---
+
+# Pew Run
+
+**Pew Run** is a fast-paced space shooter PWA where you dodge, shoot, and survive waves of enemies and bosses. Built with vanilla JavaScript and Canvas - no frameworks, just raw performance!
+
+## Gameplay
+
+- **Space Shooter**: Classic arcade-style shooting action
+- **Wave Survival**: Survive increasingly difficult enemy waves
+- **Boss Battles**: Face off against massive bosses
+- **Power-ups**: Collect upgrades to survive longer
+
+## Technical Highlights
+
+- **Vanilla JS**: No frameworks, just pure JavaScript
+- **Canvas API**: Hardware-accelerated 2D graphics
+- **PWA**: Installable progressive web app
+- **Mobile Game**: Touch controls for mobile play
+- **HTML5 Game**: Standards-based game development
+
+## Play Now
+
+[Play Pew Run](https://bigknoxy.github.io/pew-run-game/)

--- a/src/content/projects/smashmine.md
+++ b/src/content/projects/smashmine.md
@@ -1,0 +1,36 @@
+---
+title: "SmashMine"
+description: "A fast, replayable web PWA voxel mission game - smash blocks, collect loot, get OP in 3-5 minutes!"
+pubDate: 2026-04-25
+heroImage: "/assets/images/projects/smashmine-hero.svg"
+tags:
+  - "TypeScript"
+  - "PWA"
+  - "Voxel"
+  - "Game"
+  - "WebGL"
+repoUrl: "https://github.com/bigknoxy/SmashMine"
+featured: true
+---
+
+# SmashMine
+
+**SmashMine** is a fast-paced, replayable voxel mission game that runs in your browser. Smash blocks, collect loot, and get overpowered in 3-5 minute sessions!
+
+## Gameplay
+
+- **Voxel Mining**: Smash voxel blocks to uncover treasures
+- **Loot System**: Collect gear and power-ups to get stronger
+- **Quick Sessions**: Complete missions in 3-5 minutes
+- **Progression**: Get OP (overpowered) with each run
+
+## Technical Highlights
+
+- **TypeScript**: Type-safe game development
+- **PWA**: Installable progressive web app
+- **Voxel Engine**: Custom voxel rendering
+- **WebGL**: Hardware-accelerated graphics
+
+## Play Now
+
+[Play SmashMine](https://bigknoxy.github.io/SmashMine/)

--- a/src/content/projects/tiny-fixers.md
+++ b/src/content/projects/tiny-fixers.md
@@ -1,0 +1,36 @@
+---
+title: "Tiny Fixers"
+description: "A cozy mobile puzzle game - help quirky characters fix tiny problems! 🎮"
+pubDate: 2026-03-21
+heroImage: "/assets/images/projects/tiny-fixers-hero.svg"
+tags:
+  - "TypeScript"
+  - "Puzzle"
+  - "Mobile"
+  - "Game"
+  - "Cozy"
+repoUrl: "https://github.com/bigknoxy/tiny-fixers"
+featured: false
+---
+
+# Tiny Fixers
+
+**Tiny Fixers** is a cozy mobile puzzle game where you help quirky characters solve their tiny problems. It's wholesome, relaxing, and surprisingly engaging!
+
+## Gameplay
+
+- **Cozy Puzzles**: Solve gentle, satisfying puzzles
+- **Quirky Characters**: Meet memorable characters with tiny problems
+- **Mobile First**: Designed for touchscreens
+- **Relaxing**: No timers, no stress, just fixing things
+
+## Technical Highlights
+
+- **TypeScript**: Type-safe puzzle logic
+- **Mobile Optimized**: Touch-first controls
+- **Cozy Aesthetic**: Warm, inviting visuals
+- **Progressive Difficulty**: Puzzles get more interesting as you go
+
+## Play Now
+
+[Play Tiny Fixers](https://bigknoxy.github.io/tiny-fixers/)

--- a/src/content/projects/toilet-runner.md
+++ b/src/content/projects/toilet-runner.md
@@ -1,0 +1,36 @@
+---
+title: "Toilet Runner"
+description: "A silly 3D endless runner game where you play as toilet paper avoiding poop!"
+pubDate: 2026-01-19
+heroImage: "/assets/images/projects/toilet-runner-hero.svg"
+tags:
+  - "TypeScript"
+  - "3D"
+  - "Endless Runner"
+  - "Game"
+  - "WebGL"
+repoUrl: "https://github.com/bigknoxy/toilet-runner"
+featured: false
+---
+
+# Toilet Runner
+
+**Toilet Runner** is exactly what it sounds like - a ridiculous 3D endless runner where you're a roll of toilet paper trying to avoid... well, you know. It's stupid fun.
+
+## Gameplay
+
+- **Endless Running**: Keep rolling as long as you can
+- **3D Obstacles**: Dodge poop, plungers, and other bathroom hazards
+- **Silly Theme**: Embrace the absurdity
+- **High Score**: Compete for the longest run
+
+## Technical Highlights
+
+- **TypeScript**: Type-safe game logic
+- **3D Graphics**: WebGL-powered 3D rendering
+- **Endless Runner**: Procedurally generated obstacles
+- **Mobile Friendly**: Touch controls for on-the-go gaming
+
+## Play Now
+
+[Play Toilet Runner](https://bigknoxy.github.io/toilet-runner/)


### PR DESCRIPTION
## Summary

Adding 4 games that were missing from the portfolio site:

### New Games

| Game | Type | Description |
|------|------|-------------|
| **SmashMine** | Voxel PWA | Fast, replayable mining game - smash blocks, collect loot |
| **Toilet Runner** | 3D Endless Runner | Silly game where you play as toilet paper avoiding poop |
| **Tiny Fixers** | Mobile Puzzle | Cozy puzzle game - help quirky characters fix tiny problems |
| **Pew Run** | Space Shooter | Fast-paced PWA - dodge, shoot, survive waves of enemies |

### Files Added
- 4 project markdown files in src/content/projects/
- 4 SVG hero images in public/assets/images/projects/
- All games tagged with 'Game' for automatic filtering on Games page

### Verification
- [ ] Build passes
- [ ] Games appear on Projects page
- [ ] Games appear on Games page
- [ ] All images load correctly