### PR TITLE
feat: Phosphor Terminal design system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+bun install          # install deps
+bun run dev          # dev server (localhost:4321)
+bun run build        # production build → dist/
+bun run preview      # serve dist/ locally
+bun run lint         # format with Prettier
+bun run typecheck    # Astro type check
+
+# After build, generate search index:
+bunx pagefind --site dist --output-subdir _pagefind
+
+# Tests
+bun test                          # all unit tests
+bun test tests/unit/foo.test.ts   # single unit test
+npx playwright test --project=chromium  # e2e tests (requires bun run preview running)
+
+# Game bundle (built separately from main Astro build)
+bun run build:game   # outputs to dist/game/game-engine.js
+```
+
+## Architecture
+
+**Astro static site** deployed to GitHub Pages (`bigknoxy.github.io`). Two separate build pipelines:
+
+1. **Astro build** (`bun run build`) — generates all pages, components, styles
+2. **Vite game build** (`bun run build:game`) — bundles `src/game/` as a standalone ES library (`dist/game/game-engine.js`)
+
+### Content layer
+
+`src/content/` uses Astro content collections:
+- `blog/` — markdown posts (title, description, pubDate, tags, heroImage)
+- `projects/` — markdown project entries (same + demoUrl, repoUrl, featured)
+
+Schema defined in `src/content/config.ts`. Pages are generated via dynamic routes: `src/pages/blog/[...slug].astro` and `src/pages/projects/[slug].astro`.
+
+### Game engine (`src/game/`)
+
+ECS-style Canvas game. Entry: `src/game/index.js` → `GameEngine.ts`.
+
+- `entities/` — Player, Obstacle, Collectible (extend Entity base)
+- `systems/` — PhysicsSystem, RenderSystem, AudioSystem (Web Audio API)
+- `utils/` — InputHandler (keyboard + touch), ObjectPool (entity reuse)
+- `types/GameTypes.ts` — shared interfaces (GameState, GameEvent, etc.)
+
+`GameEngine` runs a fixed 60 FPS loop with delta accumulator. Uses a unified `GROUND_Y` constant shared between physics and render to prevent collision/visual misalignment. Entities managed via `EntityPool` for perf.
+
+The game is embedded via `src/components/game/MiniGame.astro`, which loads the game bundle dynamically.
+
+### Theme
+
+Two palettes defined in `tailwind.config.js`:
+- `gameboy-*` — darkest/dark/light/lightest (green LCD tones)
+- `tokyo-*` — bg/surface/border/text/accent/muted (Tokyo Night)
+
+Fonts: `font-pixel` (Press Start 2P) for game UI, `font-mono` (JetBrains Mono) for code, `font-sans` (Outfit) for body.
+
+### Search
+
+Powered by `astro-pagefind`. Index must be generated post-build via `bunx pagefind`. `SearchBar.astro` provides the UI; search results link back to the production URL.
+
+### Testing
+
+- **Unit tests** (`tests/unit/`) — run with Bun's built-in test runner; preload `tests/test-setup.ts`
+- **E2e tests** (`tests/e2e/`) — Playwright, chromium only; `baseURL` points to `https://bigknoxy.github.io` (production) unless `webServer` is active
+
+### Deployment
+
+GitHub Actions workflow at `.github/workflows/deploy.yml` deploys `main` → GitHub Pages. Static output only (`output: "static"` in `astro.config.mjs`).
+
+## Style conventions
+
+- `.astro` components, PascalCase filenames
+- Tailwind classes only — no custom CSS unless unavoidable
+- Use `@` alias for `src/` imports
+- Astro `<Image>` component for all images (sharp optimization)
+- Scan `./memory/` for relevant prior decisions before starting non-trivial tasks

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,31 +1,29 @@
 ---
+const socialLinks = [
+  { href: 'https://github.com/bigknoxy', label: 'github' },
+  { href: 'https://www.linkedin.com/in/joshua-knox-6651ba18/', label: 'linkedin' },
+];
 ---
 
 <footer class="relative z-10 border-t border-phosphor-border">
   <div class="max-w-[1100px] mx-auto px-10 py-6 flex justify-between items-center text-[10px] text-phosphor-text">
-    <span>&copy; 2025 Josh Knox</span>
+    <span>&copy; {new Date().getFullYear()} Josh Knox</span>
 
     <div class="flex gap-6 items-center">
       <span class="uptime flex items-center gap-2">
         <span class="status-dot" aria-hidden="true"></span>
         systems online
       </span>
-      <a
-        href="https://github.com/bigknoxy"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="hover:text-phosphor-bright transition-colors tracking-widest"
-      >
-        github
-      </a>
-      <a
-        href="https://www.linkedin.com/in/joshua-knox-6651ba18/"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="hover:text-phosphor-bright transition-colors tracking-widest"
-      >
-        linkedin
-      </a>
+      {socialLinks.map((link) => (
+        <a
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-phosphor-bright transition-colors tracking-widest"
+        >
+          {link.label}
+        </a>
+      ))}
     </div>
   </div>
 </footer>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,42 +1,31 @@
 ---
-// Footer.astro - Footer component with social links
 ---
 
-<footer class="bg-tokyo-surface border-t border-tokyo-border mt-16">
-  <div class="container mx-auto px-4 py-8">
-    <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-      <div class="text-tokyo-muted text-sm">
-        <p>&copy; 2025 Josh Knox.</p>
-      </div>
-      
-      <div class="flex items-center gap-6">
-        <a 
-          href="https://github.com/bigknoxy" 
-          target="_blank" 
-          rel="noopener noreferrer"
-          class="text-tokyo-muted hover:text-gameboy-light transition-colors"
-          aria-label="GitHub Profile"
-        >
-          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-          </svg>
-        </a>
-        <a 
-          href="https://www.linkedin.com/in/joshua-knox-6651ba18/" 
-          target="_blank" 
-          rel="noopener noreferrer"
-          class="text-tokyo-muted hover:text-gameboy-light transition-colors"
-          aria-label="LinkedIn Profile"
-        >
-          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
-          </svg>
-        </a>
-        
-        <span class="text-tokyo-muted text-sm italic opacity-75">
-          Inspired by Tokyo Night & GameBoy
-        </span>
-      </div>
+<footer class="relative z-10 border-t border-phosphor-border">
+  <div class="max-w-[1100px] mx-auto px-10 py-6 flex justify-between items-center text-[10px] text-phosphor-text">
+    <span>&copy; 2025 Josh Knox</span>
+
+    <div class="flex gap-6 items-center">
+      <span class="uptime flex items-center gap-2">
+        <span class="status-dot" aria-hidden="true"></span>
+        systems online
+      </span>
+      <a
+        href="https://github.com/bigknoxy"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="hover:text-phosphor-bright transition-colors tracking-widest"
+      >
+        github
+      </a>
+      <a
+        href="https://www.linkedin.com/in/joshua-knox-6651ba18/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="hover:text-phosphor-bright transition-colors tracking-widest"
+      >
+        linkedin
+      </a>
     </div>
   </div>
 </footer>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,47 +1,39 @@
 ---
-// Header.astro - Navigation header component
 import SearchBar from '../ui/SearchBar.astro';
 ---
 
-<header class="bg-tokyo-surface border-b border-tokyo-border">
-  <nav aria-label="Primary navigation" class="container mx-auto px-4 py-4">
-    <div class="flex items-center justify-between">
-      <a href="/" class="text-2xl font-pixel text-gameboy-lightest hover:text-gameboy-lightest transition-colors">
-        BIGKNOXY
+<header class="relative z-50 bg-phosphor-bg/98 border-b border-phosphor-border" style="backdrop-filter: blur(4px);">
+  <nav aria-label="Primary navigation" class="max-w-[1100px] mx-auto px-10 py-[18px] flex items-center justify-between">
+    <a href="/" class="font-pixel text-[13px] text-phosphor-bright glow-text tracking-wide" style="letter-spacing: 0.04em;">
+      BIGKNOXY
+    </a>
+
+    <ul class="hidden md:flex items-center gap-8 list-none" role="list">
+      <li><a href="/projects" class="nav-link text-phosphor-text text-[11px] tracking-widest hover:text-phosphor-bright transition-all hover:glow-text" style="letter-spacing: 0.08em;">projects</a></li>
+      <li><a href="/games" class="nav-link text-phosphor-text text-[11px] tracking-widest hover:text-phosphor-bright transition-all hover:glow-text" style="letter-spacing: 0.08em;">games</a></li>
+      <li><a href="/blog" class="nav-link text-phosphor-text text-[11px] tracking-widest hover:text-phosphor-bright transition-all hover:glow-text" style="letter-spacing: 0.08em;">blog</a></li>
+    </ul>
+
+    <div class="flex items-center gap-5">
+      <SearchBar />
+      <a
+        href="https://github.com/bigknoxy"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-phosphor-text text-[10px] tracking-widest hover:text-phosphor-bright transition-colors"
+        aria-label="GitHub Profile"
+      >
+        github
       </a>
-      
-      <div class="hidden md:flex items-center gap-8">
-        <a href="/" class="text-tokyo-text hover:text-gameboy-light transition-colors">Home</a>
-        <a href="/projects" class="text-tokyo-text hover:text-gameboy-light transition-colors">Projects</a>
-        <a href="/games" class="text-tokyo-text hover:text-gameboy-light transition-colors">🎮 Games</a>
-        <a href="/blog" class="text-tokyo-text hover:text-gameboy-light transition-colors">Blog</a>
-      </div>
-      
-      <div class="flex items-center gap-4">
-        <SearchBar />
-        <a 
-          href="https://github.com/bigknoxy" 
-          target="_blank" 
-          rel="noopener noreferrer"
-          class="text-tokyo-text hover:text-gameboy-light transition-colors"
-          aria-label="GitHub Profile"
-        >
-          <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-          </svg>
-        </a>
-        <a 
-          href="https://www.linkedin.com/in/joshua-knox-6651ba18/" 
-          target="_blank" 
-          rel="noopener noreferrer"
-          class="text-tokyo-text hover:text-gameboy-light transition-colors"
-          aria-label="LinkedIn Profile"
-        >
-          <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
-          </svg>
-        </a>
-      </div>
+      <a
+        href="https://www.linkedin.com/in/joshua-knox-6651ba18/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-phosphor-text text-[10px] tracking-widest hover:text-phosphor-bright transition-colors"
+        aria-label="LinkedIn Profile"
+      >
+        linkedin
+      </a>
     </div>
   </nav>
 </header>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,5 +1,21 @@
 ---
 import SearchBar from '../ui/SearchBar.astro';
+
+const navLinks = [
+  { href: '/projects', label: 'projects' },
+  { href: '/games', label: 'games' },
+  { href: '/blog', label: 'blog' },
+];
+
+const socialLinks = [
+  { href: 'https://github.com/bigknoxy', label: 'github', aria: 'GitHub Profile' },
+  { href: 'https://www.linkedin.com/in/joshua-knox-6651ba18/', label: 'linkedin', aria: 'LinkedIn Profile' },
+];
+
+const navLinkClass =
+  'nav-link text-phosphor-text text-[11px] tracking-widest hover:text-phosphor-bright transition-all hover:glow-text';
+const socialLinkClass =
+  'text-phosphor-text text-[10px] tracking-widest hover:text-phosphor-bright transition-colors';
 ---
 
 <header class="relative z-50 bg-phosphor-bg/98 border-b border-phosphor-border" style="backdrop-filter: blur(4px);">
@@ -9,31 +25,37 @@ import SearchBar from '../ui/SearchBar.astro';
     </a>
 
     <ul class="hidden md:flex items-center gap-8 list-none" role="list">
-      <li><a href="/projects" class="nav-link text-phosphor-text text-[11px] tracking-widest hover:text-phosphor-bright transition-all hover:glow-text" style="letter-spacing: 0.08em;">projects</a></li>
-      <li><a href="/games" class="nav-link text-phosphor-text text-[11px] tracking-widest hover:text-phosphor-bright transition-all hover:glow-text" style="letter-spacing: 0.08em;">games</a></li>
-      <li><a href="/blog" class="nav-link text-phosphor-text text-[11px] tracking-widest hover:text-phosphor-bright transition-all hover:glow-text" style="letter-spacing: 0.08em;">blog</a></li>
+      {navLinks.map((link) => (
+        <li>
+          <a href={link.href} class={navLinkClass} style="letter-spacing: 0.08em;">{link.label}</a>
+        </li>
+      ))}
     </ul>
 
     <div class="flex items-center gap-5">
       <SearchBar />
-      <a
-        href="https://github.com/bigknoxy"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="text-phosphor-text text-[10px] tracking-widest hover:text-phosphor-bright transition-colors"
-        aria-label="GitHub Profile"
-      >
-        github
-      </a>
-      <a
-        href="https://www.linkedin.com/in/joshua-knox-6651ba18/"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="text-phosphor-text text-[10px] tracking-widest hover:text-phosphor-bright transition-colors"
-        aria-label="LinkedIn Profile"
-      >
-        linkedin
-      </a>
+      {socialLinks.map((link) => (
+        <a
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          class={socialLinkClass}
+          aria-label={link.aria}
+        >
+          {link.label}
+        </a>
+      ))}
     </div>
+  </nav>
+
+  <!-- Mobile nav strip -->
+  <nav aria-label="Mobile navigation" class="md:hidden border-t border-phosphor-border">
+    <ul class="flex items-center justify-center gap-8 list-none px-10 py-3" role="list">
+      {navLinks.map((link) => (
+        <li>
+          <a href={link.href} class={navLinkClass}>{link.label}</a>
+        </li>
+      ))}
+    </ul>
   </nav>
 </header>

--- a/src/components/layout/SectionHeader.astro
+++ b/src/components/layout/SectionHeader.astro
@@ -1,0 +1,22 @@
+---
+// Phosphor section header: pixel-font label, fading rule, optional link.
+export interface Props {
+  label: string;
+  linkHref?: string;
+  linkText?: string;
+  /** Bottom margin utility (defaults to `mb-10`, matches the homepage hero rule). */
+  marginClass?: string;
+}
+
+const { label, linkHref, linkText, marginClass = 'mb-10' } = Astro.props;
+---
+
+<div class={`flex items-center gap-5 ${marginClass}`}>
+  <span class="font-pixel text-[9px] text-phosphor-bright glow-text tracking-widest whitespace-nowrap">{label}</span>
+  <div class="section-rule"></div>
+  {linkHref && linkText && (
+    <a href={linkHref} class="text-phosphor-text text-[10px] tracking-widest hover:text-phosphor-bright transition-colors whitespace-nowrap">
+      {linkText}
+    </a>
+  )}
+</div>

--- a/src/components/layout/TerminalBar.astro
+++ b/src/components/layout/TerminalBar.astro
@@ -1,0 +1,24 @@
+---
+// Terminal window title bar: three dots + uppercase title.
+// Mirrors the markup that was duplicated across every page using the
+// `.terminal-window` chrome.
+export interface Props {
+  title: string;
+  /** When true, the bar's border-bottom dims on parent `.group:hover`. */
+  groupHover?: boolean;
+}
+
+const { title, groupHover = false } = Astro.props;
+const barClass = groupHover
+  ? 'terminal-bar group-hover:border-phosphor-faint transition-colors'
+  : 'terminal-bar';
+---
+
+<div class={barClass}>
+  <div class="flex gap-[5px]">
+    <span class="terminal-dot"></span>
+    <span class="terminal-dot"></span>
+    <span class="terminal-dot"></span>
+  </div>
+  <span class="terminal-bar-title">{title}</span>
+</div>

--- a/src/components/ui/BackLink.astro
+++ b/src/components/ui/BackLink.astro
@@ -1,0 +1,15 @@
+---
+// Breadcrumb-style back link: "← cd /<path>".
+export interface Props {
+  href: string;
+  label: string;
+}
+
+const { href, label } = Astro.props;
+---
+
+<div class="mb-8 text-[11px]">
+  <a href={href} class="text-phosphor-dim hover:text-phosphor-bright transition-colors tracking-wider">
+    <span class="text-phosphor-faint">←</span> cd {label}
+  </a>
+</div>

--- a/src/components/ui/Tag.astro
+++ b/src/components/ui/Tag.astro
@@ -1,0 +1,12 @@
+---
+// Single tag chip with the standard phosphor-faint bordered style.
+export interface Props {
+  label: string;
+}
+
+const { label } = Astro.props;
+---
+
+<span class="text-[9px] px-[10px] py-[3px] border border-phosphor-faint text-phosphor-text tracking-wider">
+  {label}
+</span>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,7 +20,8 @@ const { title = 'Joshua Knox | Senior Software Engineer', description = 'Senior 
     <title>{title}</title>
     <link rel="stylesheet" href="/styles/global.css" />
   </head>
-  <body class="bg-tokyo-bg text-tokyo-text font-mono">
+  <body class="bg-phosphor-bg text-phosphor-green font-mono">
+    <div class="phosphor-grid" aria-hidden="true"></div>
     <Header />
     <slot />
   </body>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import Header from '../components/layout/Header.astro';
+import '../styles/global.css';
 
 export interface Props {
   title?: string;
@@ -18,7 +19,6 @@ const { title = 'Joshua Knox | Senior Software Engineer', description = 'Senior 
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
-    <link rel="stylesheet" href="/styles/global.css" />
   </head>
   <body class="bg-phosphor-bg text-phosphor-green font-mono">
     <div class="phosphor-grid" aria-hidden="true"></div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -16,20 +16,52 @@ const post = Astro.props;
 const { Content } = await post.render();
 ---
 
-<BaseLayout title={post.data.title}>
-  <main class="container mx-auto px-4 py-16">
-    <article class="max-w-4xl mx-auto">
-      <header class="mb-8">
-        <h1 class="text-4xl font-pixel text-gameboy-lightest mb-4">{post.data.title}</h1>
-        <p class="text-tokyo-muted mb-4">{post.data.description}</p>
-        <time class="text-sm text-tokyo-muted">
-          {post.data.pubDate.toLocaleDateString()}
-        </time>
-      </header>
-      
-      <div class="prose prose-invert max-w-none">
-        <Content />
+<BaseLayout title={`${post.data.title} | Joshua Knox`}>
+  <main class="relative z-10 max-w-[1100px] mx-auto px-10 py-16">
+
+    <div class="mb-8 text-[11px]">
+      <a href="/blog" class="text-phosphor-dim hover:text-phosphor-bright transition-colors tracking-wider">
+        <span class="text-phosphor-faint">←</span> cd /blog
+      </a>
+    </div>
+
+    <div class="terminal-window mb-6">
+      <div class="terminal-bar">
+        <div class="flex gap-[5px]">
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+        </div>
+        <span class="terminal-bar-title">{post.data.pubDate.toISOString().split('T')[0]}.md</span>
       </div>
-    </article>
+      <div class="p-8">
+        <h1 class="font-pixel text-phosphor-bright glow-text mb-4 leading-[1.5]" style="font-size: clamp(12px, 2vw, 20px);">
+          {post.data.title}
+        </h1>
+        {post.data.description && (
+          <p class="text-[13px] text-phosphor-text leading-[1.9] mb-4">{post.data.description}</p>
+        )}
+        <time class="text-[10px] text-phosphor-dim tracking-widest">
+          {post.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+        </time>
+      </div>
+    </div>
+
+    <div class="terminal-window">
+      <div class="terminal-bar">
+        <div class="flex gap-[5px]">
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+        </div>
+        <span class="terminal-bar-title">CONTENT.md</span>
+      </div>
+      <div class="p-8">
+        <article class="prose max-w-none">
+          <Content />
+        </article>
+      </div>
+    </div>
+
   </main>
 </BaseLayout>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,6 +1,8 @@
 ---
 import { type CollectionEntry, getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import BackLink from '../../components/ui/BackLink.astro';
+import TerminalBar from '../../components/layout/TerminalBar.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
@@ -14,26 +16,21 @@ type Props = CollectionEntry<'blog'>;
 
 const post = Astro.props;
 const { Content } = await post.render();
+const isoDate = post.data.pubDate.toISOString().split('T')[0];
+const longDate = post.data.pubDate.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
 ---
 
 <BaseLayout title={`${post.data.title} | Joshua Knox`}>
   <main class="relative z-10 max-w-[1100px] mx-auto px-10 py-16">
 
-    <div class="mb-8 text-[11px]">
-      <a href="/blog" class="text-phosphor-dim hover:text-phosphor-bright transition-colors tracking-wider">
-        <span class="text-phosphor-faint">←</span> cd /blog
-      </a>
-    </div>
+    <BackLink href="/blog" label="/blog" />
 
     <div class="terminal-window mb-6">
-      <div class="terminal-bar">
-        <div class="flex gap-[5px]">
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-        </div>
-        <span class="terminal-bar-title">{post.data.pubDate.toISOString().split('T')[0]}.md</span>
-      </div>
+      <TerminalBar title={`${isoDate}.md`} />
       <div class="p-8">
         <h1 class="font-pixel text-phosphor-bright glow-text mb-4 leading-[1.5]" style="font-size: clamp(12px, 2vw, 20px);">
           {post.data.title}
@@ -41,21 +38,14 @@ const { Content } = await post.render();
         {post.data.description && (
           <p class="text-[13px] text-phosphor-text leading-[1.9] mb-4">{post.data.description}</p>
         )}
-        <time class="text-[10px] text-phosphor-dim tracking-widest">
-          {post.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+        <time datetime={isoDate} class="text-[10px] text-phosphor-dim tracking-widest">
+          {longDate}
         </time>
       </div>
     </div>
 
     <div class="terminal-window">
-      <div class="terminal-bar">
-        <div class="flex gap-[5px]">
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-        </div>
-        <span class="terminal-bar-title">CONTENT.md</span>
-      </div>
+      <TerminalBar title="CONTENT.md" />
       <div class="p-8">
         <article class="prose max-w-none">
           <Content />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,18 +1,21 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import SectionHeader from '../../components/layout/SectionHeader.astro';
+import TerminalBar from '../../components/layout/TerminalBar.astro';
 import { getCollection } from 'astro:content';
 
 const posts = await getCollection('blog');
 const sorted = posts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());
+
+function isoDate(d: Date): string {
+  return d.toISOString().split('T')[0];
+}
 ---
 
 <BaseLayout title="Blog | Joshua Knox">
   <main class="relative z-10 max-w-[1100px] mx-auto px-10 py-16">
 
-    <div class="flex items-center gap-5 mb-12">
-      <span class="font-pixel text-[9px] text-phosphor-bright glow-text tracking-widest whitespace-nowrap">BLOG.LOG</span>
-      <div class="section-rule"></div>
-    </div>
+    <SectionHeader label="BLOG.LOG" marginClass="mb-12" />
 
     <div class="flex flex-col gap-5">
       {sorted.map((post) => (
@@ -22,14 +25,7 @@ const sorted = posts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.ge
             class="terminal-window block no-underline transition-all duration-200 group hover:border-phosphor-green"
             style="text-decoration: none;"
           >
-            <div class="terminal-bar">
-              <div class="flex gap-[5px]">
-                <span class="terminal-dot"></span>
-                <span class="terminal-dot"></span>
-                <span class="terminal-dot"></span>
-              </div>
-              <span class="terminal-bar-title">{post.data.pubDate.toISOString().split('T')[0]}.md</span>
-            </div>
+            <TerminalBar title={`${isoDate(post.data.pubDate)}.md`} />
             <div class="p-7">
               <h2 class="font-pixel text-[10px] text-phosphor-bright group-hover:glow-text mb-3 leading-[1.7] tracking-wide transition-all">
                 {post.data.title}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -3,24 +3,44 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 
 const posts = await getCollection('blog');
+const sorted = posts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());
 ---
 
-<BaseLayout title="Blog - BigKnoxy Portfolio">
-  <main class="container mx-auto px-4 py-16">
-    <h1 class="text-4xl font-pixel text-gameboy-lightest mb-8">BLOG</h1>
-    
-    <div class="grid gap-8">
-      {posts.map((post) => (
-        <article class="bg-tokyo-surface border border-tokyo-border rounded-lg p-6">
-          <h2 class="text-2xl font-pixel text-gameboy-light mb-2">
-            <a href={`/blog/${post.slug}`} class="hover:text-gameboy-lightest transition-colors">
-              {post.data.title}
-            </a>
-          </h2>
-          <p class="text-tokyo-muted mb-4">{post.data.description}</p>
-          <time class="text-sm text-tokyo-muted">
-            {post.data.pubDate.toLocaleDateString()}
-          </time>
+<BaseLayout title="Blog | Joshua Knox">
+  <main class="relative z-10 max-w-[1100px] mx-auto px-10 py-16">
+
+    <div class="flex items-center gap-5 mb-12">
+      <span class="font-pixel text-[9px] text-phosphor-bright glow-text tracking-widest whitespace-nowrap">BLOG.LOG</span>
+      <div class="section-rule"></div>
+    </div>
+
+    <div class="flex flex-col gap-5">
+      {sorted.map((post) => (
+        <article>
+          <a
+            href={`/blog/${post.slug}`}
+            class="terminal-window block no-underline transition-all duration-200 group hover:border-phosphor-green"
+            style="text-decoration: none;"
+          >
+            <div class="terminal-bar">
+              <div class="flex gap-[5px]">
+                <span class="terminal-dot"></span>
+                <span class="terminal-dot"></span>
+                <span class="terminal-dot"></span>
+              </div>
+              <span class="terminal-bar-title">{post.data.pubDate.toISOString().split('T')[0]}.md</span>
+            </div>
+            <div class="p-7">
+              <h2 class="font-pixel text-[10px] text-phosphor-bright group-hover:glow-text mb-3 leading-[1.7] tracking-wide transition-all">
+                {post.data.title}
+              </h2>
+              {post.data.description && (
+                <p class="text-[12px] text-phosphor-text leading-[1.9]">
+                  {post.data.description}
+                </p>
+              )}
+            </div>
+          </a>
         </article>
       ))}
     </div>

--- a/src/pages/games.astro
+++ b/src/pages/games.astro
@@ -1,42 +1,44 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import SectionHeader from '../components/layout/SectionHeader.astro';
+import TerminalBar from '../components/layout/TerminalBar.astro';
+import Tag from '../components/ui/Tag.astro';
 import { getCollection } from 'astro:content';
+
+const SPECIAL_GAME_TITLES = new Set(['chicken-mob', 'chop-it-like-its-hawt', 'chopIt']);
 
 const games = await getCollection('projects', ({ data }) => {
   const tags = data.tags || [];
   const title = data.title || '';
-  return tags.includes('Game') ||
-         tags.includes('game') ||
-         title.toLowerCase().includes('game') ||
-         title === 'chicken-mob' ||
-         title === 'chop-it-like-its-hawt' ||
-         title === 'chopIt';
+  return (
+    tags.includes('Game') ||
+    tags.includes('game') ||
+    title.toLowerCase().includes('game') ||
+    SPECIAL_GAME_TITLES.has(title)
+  );
 });
 
 const sortedGames = games.sort((a, b) => {
-  if (a.data.featured && !b.data.featured) return -1;
-  if (!a.data.featured && b.data.featured) return 1;
+  if (a.data.featured !== b.data.featured) return a.data.featured ? -1 : 1;
   return new Date(b.data.pubDate).getTime() - new Date(a.data.pubDate).getTime();
 });
+
+function fileName(title: string): string {
+  return title.toUpperCase().replace(/\s+/g, '_');
+}
+
+function isGameTag(tag: string): boolean {
+  return tag !== 'Game' && tag !== 'game';
+}
 ---
 
 <BaseLayout title="Games | Joshua Knox">
   <main class="relative z-10 max-w-[1100px] mx-auto px-10 py-16">
 
-    <div class="flex items-center gap-5 mb-12">
-      <span class="font-pixel text-[9px] text-phosphor-bright glow-text tracking-widest whitespace-nowrap">ARCADE.EXE</span>
-      <div class="section-rule"></div>
-    </div>
+    <SectionHeader label="ARCADE.EXE" marginClass="mb-12" />
 
     <div class="terminal-window mb-10">
-      <div class="terminal-bar">
-        <div class="flex gap-[5px]">
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-        </div>
-        <span class="terminal-bar-title">ARCADE.SYS</span>
-      </div>
+      <TerminalBar title="ARCADE.SYS" />
       <div class="p-8 text-center">
         <h1 class="font-pixel text-phosphor-bright glow-text-bright mb-4 tracking-wider" style="font-size: clamp(18px, 4vw, 36px);">
           ARCADE
@@ -49,54 +51,41 @@ const sortedGames = games.sort((a, b) => {
     </div>
 
     <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {sortedGames.map((game) => (
-        <a
-          href={game.data.demoUrl || game.data.repoUrl || `/projects/${game.slug}`}
-          target={game.data.demoUrl ? "_blank" : undefined}
-          rel={game.data.demoUrl ? "noopener noreferrer" : undefined}
-          class="terminal-window block no-underline transition-all duration-200 group hover:border-phosphor-green"
-          style="text-decoration: none;"
-        >
-          <div class="terminal-bar">
-            <div class="flex gap-[5px]">
-              <span class="terminal-dot"></span>
-              <span class="terminal-dot"></span>
-              <span class="terminal-dot"></span>
+      {sortedGames.map((game) => {
+        const href = game.data.demoUrl || game.data.repoUrl || `/projects/${game.slug}`;
+        const isExternal = Boolean(game.data.demoUrl);
+        const ctaLabel = game.data.demoUrl ? 'play --now →' : 'view --project →';
+        return (
+          <a
+            href={href}
+            target={isExternal ? '_blank' : undefined}
+            rel={isExternal ? 'noopener noreferrer' : undefined}
+            class="terminal-window block no-underline transition-all duration-200 group hover:border-phosphor-green"
+            style="text-decoration: none;"
+          >
+            <TerminalBar title={`${fileName(game.data.title)}.ROM`} />
+            <div class="p-7">
+              <h2 class="font-pixel text-[10px] text-phosphor-bright group-hover:glow-text mb-3 leading-[1.7] tracking-wide transition-all">
+                {game.data.title}
+              </h2>
+              <p class="text-[12px] text-phosphor-text leading-[1.9] mb-5 line-clamp-3">
+                {game.data.description}
+              </p>
+              <div class="flex flex-wrap gap-2 mb-5">
+                {game.data.tags.filter(isGameTag).map((tag: string) => <Tag label={tag} />)}
+              </div>
+              <div class="text-[10px] text-phosphor-dim group-hover:text-phosphor-green transition-colors tracking-wider">
+                <span class="text-phosphor-faint">$</span> {ctaLabel}
+              </div>
             </div>
-            <span class="terminal-bar-title">{game.data.title.toUpperCase().replace(/\s+/g, '_')}.ROM</span>
-          </div>
-          <div class="p-7">
-            <h2 class="font-pixel text-[10px] text-phosphor-bright group-hover:glow-text mb-3 leading-[1.7] tracking-wide transition-all">
-              {game.data.title}
-            </h2>
-            <p class="text-[12px] text-phosphor-text leading-[1.9] mb-5 line-clamp-3">
-              {game.data.description}
-            </p>
-            <div class="flex flex-wrap gap-2 mb-5">
-              {game.data.tags.filter((t: string) => t !== 'Game' && t !== 'game').map((tag: string) => (
-                <span class="text-[9px] px-[10px] py-[3px] border border-phosphor-faint text-phosphor-text tracking-wider">
-                  {tag}
-                </span>
-              ))}
-            </div>
-            <div class="text-[10px] text-phosphor-dim group-hover:text-phosphor-green transition-colors tracking-wider">
-              <span class="text-phosphor-faint">$</span> {game.data.demoUrl ? 'play --now →' : 'view --project →'}
-            </div>
-          </div>
-        </a>
-      ))}
+          </a>
+        );
+      })}
     </div>
 
     <!-- Code Runner teaser -->
     <div class="terminal-window mt-10">
-      <div class="terminal-bar">
-        <div class="flex gap-[5px]">
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-        </div>
-        <span class="terminal-bar-title">CODE_RUNNER.ROM</span>
-      </div>
+      <TerminalBar title="CODE_RUNNER.ROM" />
       <div class="p-8 text-center">
         <h3 class="font-pixel text-[12px] text-phosphor-bright glow-text mb-3">Code Runner</h3>
         <p class="text-[13px] text-phosphor-text leading-[1.9] mb-6">

--- a/src/pages/games.astro
+++ b/src/pages/games.astro
@@ -5,7 +5,7 @@ import { getCollection } from 'astro:content';
 const games = await getCollection('projects', ({ data }) => {
   const tags = data.tags || [];
   const title = data.title || '';
-  return tags.includes('Game') || 
+  return tags.includes('Game') ||
          tags.includes('game') ||
          title.toLowerCase().includes('game') ||
          title === 'chicken-mob' ||
@@ -13,114 +13,103 @@ const games = await getCollection('projects', ({ data }) => {
          title === 'chopIt';
 });
 
-// Sort by featured first, then by date
 const sortedGames = games.sort((a, b) => {
   if (a.data.featured && !b.data.featured) return -1;
   if (!a.data.featured && b.data.featured) return 1;
   return new Date(b.data.pubDate).getTime() - new Date(a.data.pubDate).getTime();
 });
-
-const gameIcons: Record<string, string> = {
-  'chicken-mob': '🐔',
-  'chop-it-like-its-hawt': '🪓',
-  'chopIt': '🔥',
-  'code-runner': '🏃',
-  'default': '🎮'
-};
 ---
 
-<BaseLayout title="Games | Joshua Knox - Game Dev Experiments">
-  <main class="container mx-auto px-4 py-16 md:py-24">
-    <div class="max-w-6xl mx-auto">
-      <!-- Arcade Header -->
-      <div class="text-center mb-16">
-        <div class="inline-block bg-tokyo-surface border-2 border-gameboy-light rounded-lg p-6 mb-6 shadow-lg shadow-gameboy-light/20">
-          <h1 class="text-5xl md:text-7xl font-pixel text-gameboy-lightest mb-4 tracking-wider">
-            ARCADE
-          </h1>
-          <div class="flex items-center justify-center gap-4 text-gameboy-light">
-            <span class="text-2xl">👾</span>
-            <span class="font-pixel text-sm tracking-widest">INSERT COIN TO PLAY</span>
-            <span class="text-2xl">👾</span>
-          </div>
+<BaseLayout title="Games | Joshua Knox">
+  <main class="relative z-10 max-w-[1100px] mx-auto px-10 py-16">
+
+    <div class="flex items-center gap-5 mb-12">
+      <span class="font-pixel text-[9px] text-phosphor-bright glow-text tracking-widest whitespace-nowrap">ARCADE.EXE</span>
+      <div class="section-rule"></div>
+    </div>
+
+    <div class="terminal-window mb-10">
+      <div class="terminal-bar">
+        <div class="flex gap-[5px]">
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
         </div>
-        <p class="text-tokyo-muted text-lg max-w-2xl mx-auto">
-          A collection of browser-based games and experiments. Mostly built to learn things, 
-          occasionally built just for fun. No quarters required.
+        <span class="terminal-bar-title">ARCADE.SYS</span>
+      </div>
+      <div class="p-8 text-center">
+        <h1 class="font-pixel text-phosphor-bright glow-text-bright mb-4 tracking-wider" style="font-size: clamp(18px, 4vw, 36px);">
+          ARCADE
+        </h1>
+        <p class="text-[13px] text-phosphor-text leading-[1.9] max-w-2xl mx-auto">
+          Browser-based games and experiments. Mostly built to learn things,
+          occasionally just for fun. No quarters required.
         </p>
-      </div>
-
-      <!-- Games Grid -->
-      <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-        {sortedGames.map((game) => {
-          const icon = gameIcons[game.data.title] || gameIcons['default'];
-          return (
-            <a 
-              href={game.data.demoUrl || game.data.repoUrl || `/projects/${game.slug}`}
-              target={game.data.demoUrl ? "_blank" : undefined}
-              rel={game.data.demoUrl ? "noopener noreferrer" : undefined}
-              class="group block bg-tokyo-surface border-2 border-tokyo-border rounded-xl overflow-hidden hover:border-gameboy-light transition-all hover:shadow-xl hover:shadow-gameboy-light/10 transform hover:-translate-y-2"
-            >
-              {/* Game Card Header */}
-              <div class="bg-gradient-to-br from-gameboy-dark to-tokyo-surface p-8 text-center border-b border-tokyo-border">
-                <div class="text-6xl mb-4 transform group-hover:scale-110 transition-transform">
-                  {icon}
-                </div>
-                <h2 class="text-2xl font-pixel text-gameboy-lightest group-hover:text-gameboy-light transition-colors">
-                  {game.data.title}
-                </h2>
-              </div>
-              
-              {/* Game Card Body */}
-              <div class="p-6">
-                <p class="text-tokyo-text mb-6 line-clamp-3 leading-relaxed">
-                  {game.data.description}
-                </p>
-                
-                <div class="flex flex-wrap gap-2 mb-6">
-                  {game.data.tags.filter(t => t !== 'Game' && t !== 'game').map((tag) => (
-                    <span class="text-xs px-2 py-1 bg-tokyo-bg text-tokyo-muted rounded border border-tokyo-border font-pixel">
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-                
-                <div class="flex items-center justify-between">
-                  <span class="text-gameboy-light font-pixel text-sm group-hover:text-gameboy-lightest transition-colors">
-                    {game.data.demoUrl ? 'PLAY NOW →' : 'VIEW PROJECT →'}
-                  </span>
-                  {game.data.featured && (
-                    <span class="text-xs bg-gameboy-light/20 text-gameboy-light px-2 py-1 rounded font-pixel">
-                      ⭐ FEATURED
-                    </span>
-                  )}
-                </div>
-              </div>
-            </a>
-          );
-        })}
-      </div>
-
-      {/* Code Runner - Homepage Game Teaser */}
-      <div class="mt-16 bg-tokyo-surface border-2 border-tokyo-border rounded-xl p-8 text-center">
-        <div class="text-4xl mb-4">🏃</div>
-        <h3 class="text-2xl font-pixel text-gameboy-lightest mb-2">Code Runner</h3>
-        <p class="text-tokyo-muted mb-4">
-          The mini-game on my homepage. Jump over bugs, collect features, ship code!
-        </p>
-        <a 
-          href="/" 
-          class="inline-block bg-gameboy-light/20 hover:bg-gameboy-light/30 text-gameboy-light font-pixel px-6 py-3 rounded transition-colors"
-        >
-          PLAY ON HOMEPAGE →
-        </a>
-      </div>
-
-      {/* Footer Note */}
-      <div class="mt-16 text-center text-tokyo-muted text-sm">
-        <p class="font-pixel mb-2">HIGH SCORE: 9999</p>
-        <p>Built with TypeScript, Canvas, and too much caffeine.</p>
       </div>
     </div>
+
+    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      {sortedGames.map((game) => (
+        <a
+          href={game.data.demoUrl || game.data.repoUrl || `/projects/${game.slug}`}
+          target={game.data.demoUrl ? "_blank" : undefined}
+          rel={game.data.demoUrl ? "noopener noreferrer" : undefined}
+          class="terminal-window block no-underline transition-all duration-200 group hover:border-phosphor-green"
+          style="text-decoration: none;"
+        >
+          <div class="terminal-bar">
+            <div class="flex gap-[5px]">
+              <span class="terminal-dot"></span>
+              <span class="terminal-dot"></span>
+              <span class="terminal-dot"></span>
+            </div>
+            <span class="terminal-bar-title">{game.data.title.toUpperCase().replace(/\s+/g, '_')}.ROM</span>
+          </div>
+          <div class="p-7">
+            <h2 class="font-pixel text-[10px] text-phosphor-bright group-hover:glow-text mb-3 leading-[1.7] tracking-wide transition-all">
+              {game.data.title}
+            </h2>
+            <p class="text-[12px] text-phosphor-text leading-[1.9] mb-5 line-clamp-3">
+              {game.data.description}
+            </p>
+            <div class="flex flex-wrap gap-2 mb-5">
+              {game.data.tags.filter((t: string) => t !== 'Game' && t !== 'game').map((tag: string) => (
+                <span class="text-[9px] px-[10px] py-[3px] border border-phosphor-faint text-phosphor-text tracking-wider">
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <div class="text-[10px] text-phosphor-dim group-hover:text-phosphor-green transition-colors tracking-wider">
+              <span class="text-phosphor-faint">$</span> {game.data.demoUrl ? 'play --now →' : 'view --project →'}
+            </div>
+          </div>
+        </a>
+      ))}
+    </div>
+
+    <!-- Code Runner teaser -->
+    <div class="terminal-window mt-10">
+      <div class="terminal-bar">
+        <div class="flex gap-[5px]">
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+        </div>
+        <span class="terminal-bar-title">CODE_RUNNER.ROM</span>
+      </div>
+      <div class="p-8 text-center">
+        <h3 class="font-pixel text-[12px] text-phosphor-bright glow-text mb-3">Code Runner</h3>
+        <p class="text-[13px] text-phosphor-text leading-[1.9] mb-6">
+          The mini-game on my homepage. Jump over bugs, collect features, ship code!
+        </p>
+        <a href="/" class="btn-ghost-phosphor">play on homepage</a>
+      </div>
+    </div>
+
+    <div class="mt-10 text-center text-phosphor-text text-[10px] tracking-widest">
+      <div class="font-pixel mb-2">HIGH SCORE: 9999</div>
+      <div>Built with TypeScript, Canvas API, and too much caffeine.</div>
+    </div>
+
   </main>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,12 +1,13 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Footer from '../components/layout/Footer.astro';
+import SectionHeader from '../components/layout/SectionHeader.astro';
+import TerminalBar from '../components/layout/TerminalBar.astro';
 import MiniGame from '../components/game/MiniGame.astro';
+import Tag from '../components/ui/Tag.astro';
 import { getCollection } from 'astro:content';
 
-const projects = await getCollection('projects', ({ data }) => {
-  return data.featured === true;
-});
+const projects = await getCollection('projects', ({ data }) => data.featured === true);
 
 const skills = [
   { name: 'C# / .NET', pct: '95%' },
@@ -16,13 +17,17 @@ const skills = [
   { name: 'Security & Privacy', pct: '82%' },
   { name: 'TypeScript', pct: '78%' },
 ];
+
+function fileName(title: string): string {
+  return title.toUpperCase().replace(/\s+/g, '_');
+}
 ---
 
 <BaseLayout title="Joshua Knox - Senior Software Engineer | Problem Solver">
   <main class="relative z-10 max-w-[1100px] mx-auto px-10">
 
     <!-- ── HERO ── -->
-    <section class="py-[88px] pb-[72px] border-b border-phosphor-border grid gap-16 items-center" style="grid-template-columns: 1fr 380px;">
+    <section class="py-[88px] pb-[72px] border-b border-phosphor-border grid grid-cols-1 md:grid-cols-[1fr_380px] gap-16 items-center">
       <!-- Left: identity -->
       <div>
         <div class="text-[11px] text-phosphor-text mb-7 tracking-wider">
@@ -51,14 +56,7 @@ const skills = [
 
       <!-- Right: STATS.SYS terminal panel -->
       <div class="terminal-window">
-        <div class="terminal-bar">
-          <div class="flex gap-[5px]">
-            <span class="terminal-dot"></span>
-            <span class="terminal-dot"></span>
-            <span class="terminal-dot"></span>
-          </div>
-          <span class="terminal-bar-title">STATS.SYS</span>
-        </div>
+        <TerminalBar title="STATS.SYS" />
         <div class="p-6">
           <div class="text-[11px] text-phosphor-text mb-4">
             <span class="text-phosphor-bright glow-text">$</span> josh --skills --verbose
@@ -85,13 +83,7 @@ const skills = [
 
     <!-- ── FEATURED WORK ── -->
     <section class="py-16 border-b border-phosphor-border">
-      <div class="flex items-center gap-5 mb-10">
-        <span class="font-pixel text-[9px] text-phosphor-bright glow-text tracking-widest whitespace-nowrap">FEATURED.LOG</span>
-        <div class="section-rule"></div>
-        <a href="/projects" class="text-phosphor-text text-[10px] tracking-widest hover:text-phosphor-bright transition-colors whitespace-nowrap">
-          all_projects →
-        </a>
-      </div>
+      <SectionHeader label="FEATURED.LOG" linkHref="/projects" linkText="all_projects →" />
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         {projects.map((project) => (
@@ -100,14 +92,7 @@ const skills = [
             class="terminal-window block no-underline transition-all duration-200 group hover:border-phosphor-green"
             style="text-decoration: none;"
           >
-            <div class="terminal-bar group-hover:border-phosphor-faint transition-colors">
-              <div class="flex gap-[5px]">
-                <span class="terminal-dot"></span>
-                <span class="terminal-dot"></span>
-                <span class="terminal-dot"></span>
-              </div>
-              <span class="terminal-bar-title">{project.data.title.toUpperCase().replace(/\s+/g, '_')}.EXE</span>
-            </div>
+            <TerminalBar title={`${fileName(project.data.title)}.EXE`} groupHover />
             <div class="p-7 group-hover:glow-border transition-all">
               <h3 class="font-pixel text-[10px] text-phosphor-bright group-hover:glow-text mb-[14px] leading-[1.7] tracking-wide transition-all">
                 {project.data.title}
@@ -116,11 +101,7 @@ const skills = [
                 {project.data.description}
               </p>
               <div class="flex flex-wrap gap-2">
-                {project.data.tags.slice(0, 4).map((tag) => (
-                  <span class="text-[9px] px-[10px] py-[3px] border border-phosphor-faint text-phosphor-text tracking-wider">
-                    {tag}
-                  </span>
-                ))}
+                {project.data.tags.slice(0, 4).map((tag) => <Tag label={tag} />)}
               </div>
             </div>
           </a>
@@ -130,19 +111,9 @@ const skills = [
 
     <!-- ── MINI GAME ── -->
     <section class="py-16 border-b border-phosphor-border">
-      <div class="flex items-center gap-5 mb-10">
-        <span class="font-pixel text-[9px] text-phosphor-bright glow-text tracking-widest whitespace-nowrap">TAKE_A_BREAK.EXE</span>
-        <div class="section-rule"></div>
-      </div>
+      <SectionHeader label="TAKE_A_BREAK.EXE" />
       <div class="terminal-window inline-block overflow-hidden">
-        <div class="terminal-bar">
-          <div class="flex gap-[5px]">
-            <span class="terminal-dot"></span>
-            <span class="terminal-dot"></span>
-            <span class="terminal-dot"></span>
-          </div>
-          <span class="terminal-bar-title">MINIGAME.SYS</span>
-        </div>
+        <TerminalBar title="MINIGAME.SYS" />
         <MiniGame />
       </div>
     </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,110 +8,146 @@ const projects = await getCollection('projects', ({ data }) => {
   return data.featured === true;
 });
 
-// Skills data
 const skills = [
-  { name: 'C#', icon: '💻' },
-  { name: '.NET', icon: '🌐' },
-  { name: 'Cloud (AWS/Azure)', icon: '☁️' },
-  { name: 'AI/LLMs', icon: '🤖' },
-  { name: 'Systems Architecture', icon: '🏗️' },
-  { name: 'Security & Privacy', icon: '🛡️' }
+  { name: 'C# / .NET', pct: '95%' },
+  { name: 'AI / LLMs', pct: '88%' },
+  { name: 'Cloud (AWS/Azure)', pct: '90%' },
+  { name: 'Architecture', pct: '93%' },
+  { name: 'Security & Privacy', pct: '82%' },
+  { name: 'TypeScript', pct: '78%' },
 ];
 ---
 
 <BaseLayout title="Joshua Knox - Senior Software Engineer | Problem Solver">
-  <main class="container mx-auto px-4 py-16 md:py-24">
-    <div class="max-w-4xl mx-auto">
-      <!-- Hero Section -->
-      <section class="text-center mb-24">
-        <h1 class="text-5xl md:text-7xl font-pixel text-gameboy-lightest mb-8 leading-tight">
-          JOSH KNOX
+  <main class="relative z-10 max-w-[1100px] mx-auto px-10">
+
+    <!-- ── HERO ── -->
+    <section class="py-[88px] pb-[72px] border-b border-phosphor-border grid gap-16 items-center" style="grid-template-columns: 1fr 380px;">
+      <!-- Left: identity -->
+      <div>
+        <div class="text-[11px] text-phosphor-text mb-7 tracking-wider">
+          <span class="text-phosphor-bright glow-text">josh@bigknoxy:~$</span>&nbsp;./init --mode=portfolio --env=prod
+        </div>
+
+        <h1 class="font-pixel text-phosphor-bright glow-text-bright mb-7 leading-[1.3] tracking-wide" style="font-size: clamp(26px, 4vw, 48px);">
+          JOSH<br>KNOX<span class="cursor-blink"></span>
         </h1>
-        <p class="text-2xl md:text-3xl font-semibold text-gameboy-light mb-8 max-w-3xl mx-auto leading-relaxed">
-          Senior Software Engineer | Problem Solver | Building with Kindness & Precision
-        </p>
-        <p class="text-xl text-tokyo-text mb-12 max-w-2xl mx-auto leading-relaxed">
-          With over 18 years of experience, I am a software developer dedicated to solving complex technical problems through a lens of technical excellence and human kindness.
-        </p>
-        
-        <div class="flex flex-wrap justify-center gap-4">
-          <a href="/projects" class="px-8 py-4 bg-gameboy-dark text-white font-pixel text-sm rounded-lg hover:bg-gameboy-light transition-all transform hover:scale-105 shadow-lg">
-            VIEW PROJECTS
-          </a>
-          <a href="/blog" class="px-8 py-4 border-2 border-gameboy-light text-gameboy-light font-pixel text-sm rounded-lg hover:border-gameboy-lightest hover:text-gameboy-lightest transition-all transform hover:scale-105">
-            READ BLOG
-          </a>
-        </div>
-      </section>
 
-      <!-- Skills / Expertise -->
-      <section class="mb-24 px-6 py-12 bg-tokyo-surface/50 border border-tokyo-border rounded-2xl">
-        <h2 class="text-2xl font-pixel text-gameboy-lightest mb-12 text-center">CORE EXPERTISE</h2>
-        <div class="grid grid-cols-2 md:grid-cols-3 gap-8">
-          {skills.map(skill => (
-            <div class="flex flex-col items-center text-center group">
-              <span class="text-4xl mb-4 group-hover:scale-110 transition-transform">
-                {skill.icon}
-              </span>
-              <span class="text-lg font-semibold text-tokyo-text">{skill.name}</span>
-            </div>
-          ))}
+        <div class="text-[11px] text-phosphor-green mb-5 tracking-widest">
+          <span class="text-phosphor-text">title:</span>&nbsp;Innovation Engineer &amp; Sr. Software Developer
         </div>
-      </section>
 
-      <!-- Featured Projects Section -->
-      <section class="mb-24">
-        <div class="flex items-center justify-between mb-12">
-          <h2 class="text-3xl font-pixel text-gameboy-lightest">FEATURED WORK</h2>
-          <a href="/projects" class="text-gameboy-light hover:text-gameboy-lightest transition-colors font-semibold">
-            All Projects →
-          </a>
+        <p class="text-[13px] text-phosphor-text leading-[1.9] mb-11 max-w-[520px]">
+          18 years of shipping things that matter. Building AI systems, distributed
+          architecture, and developer tooling — with the conviction that great software
+          is both technically excellent and deeply human.
+        </p>
+
+        <div class="flex gap-4 flex-wrap items-center">
+          <a href="/projects" class="btn-phosphor">VIEW WORK</a>
+          <a href="/blog" class="btn-ghost-phosphor">cat blog</a>
         </div>
-        
-        <div class="grid gap-8 md:grid-cols-2">
-          {projects.map((project) => (
-            <a 
-              href={`/projects/${project.slug}`} 
-              class="group block bg-tokyo-surface border border-tokyo-border rounded-xl overflow-hidden hover:border-gameboy-light transition-all hover:shadow-2xl hover:shadow-gameboy-light/10"
-            >
-              <div class="aspect-video overflow-hidden">
-                <img 
-                  src={project.data.heroImage} 
-                  alt={project.data.title}
-                  class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-                />
-              </div>
-              <div class="p-8">
-                <h3 class="text-2xl font-pixel text-gameboy-light mb-4 group-hover:text-gameboy-lightest transition-colors">
-                  {project.data.title}
-                </h3>
-                <p class="text-tokyo-text mb-6 line-clamp-2 leading-relaxed">
-                  {project.data.description}
-                </p>
-                <div class="flex flex-wrap gap-2">
-                  {project.data.tags.slice(0, 4).map((tag) => (
-                    <span class="text-xs px-2 py-1 bg-tokyo-bg text-tokyo-muted rounded border border-tokyo-border">
-                      {tag}
-                    </span>
-                  ))}
+      </div>
+
+      <!-- Right: STATS.SYS terminal panel -->
+      <div class="terminal-window">
+        <div class="terminal-bar">
+          <div class="flex gap-[5px]">
+            <span class="terminal-dot"></span>
+            <span class="terminal-dot"></span>
+            <span class="terminal-dot"></span>
+          </div>
+          <span class="terminal-bar-title">STATS.SYS</span>
+        </div>
+        <div class="p-6">
+          <div class="text-[11px] text-phosphor-text mb-4">
+            <span class="text-phosphor-bright glow-text">$</span> josh --skills --verbose
+          </div>
+          <div class="flex flex-col gap-[14px]">
+            {skills.map((skill) => (
+              <div class="flex flex-col gap-[6px]">
+                <div class="flex justify-between text-[10px]">
+                  <span class="text-phosphor-green">{skill.name}</span>
+                  <span class="text-phosphor-text">{skill.pct}</span>
+                </div>
+                <div class="h-[4px] bg-phosphor-faint relative overflow-hidden">
+                  <div
+                    class="absolute inset-y-0 left-0 bg-phosphor-green stat-bar-fill"
+                    style={`box-shadow: 0 0 6px #9bbc0f; --pct: ${skill.pct};`}
+                  ></div>
                 </div>
               </div>
-            </a>
-          ))}
+            ))}
+          </div>
         </div>
-      </section>
-      
-      <section class="mb-24 text-center">
-        <h2 class="text-2xl font-pixel text-gameboy-lightest mb-12">TAKE A BREAK</h2>
-        <div class="inline-block bg-tokyo-surface border-2 border-tokyo-border rounded-xl overflow-hidden">
-           <MiniGame class="mx-auto" />
-        </div>
-      </section>
-      
-      <div class="text-center text-tokyo-muted pb-12">
       </div>
-    </div>
+    </section>
+
+    <!-- ── FEATURED WORK ── -->
+    <section class="py-16 border-b border-phosphor-border">
+      <div class="flex items-center gap-5 mb-10">
+        <span class="font-pixel text-[9px] text-phosphor-bright glow-text tracking-widest whitespace-nowrap">FEATURED.LOG</span>
+        <div class="section-rule"></div>
+        <a href="/projects" class="text-phosphor-text text-[10px] tracking-widest hover:text-phosphor-bright transition-colors whitespace-nowrap">
+          all_projects →
+        </a>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {projects.map((project) => (
+          <a
+            href={`/projects/${project.slug}`}
+            class="terminal-window block no-underline transition-all duration-200 group hover:border-phosphor-green"
+            style="text-decoration: none;"
+          >
+            <div class="terminal-bar group-hover:border-phosphor-faint transition-colors">
+              <div class="flex gap-[5px]">
+                <span class="terminal-dot"></span>
+                <span class="terminal-dot"></span>
+                <span class="terminal-dot"></span>
+              </div>
+              <span class="terminal-bar-title">{project.data.title.toUpperCase().replace(/\s+/g, '_')}.EXE</span>
+            </div>
+            <div class="p-7 group-hover:glow-border transition-all">
+              <h3 class="font-pixel text-[10px] text-phosphor-bright group-hover:glow-text mb-[14px] leading-[1.7] tracking-wide transition-all">
+                {project.data.title}
+              </h3>
+              <p class="text-[12px] text-phosphor-text leading-[1.9] mb-[22px] line-clamp-3">
+                {project.data.description}
+              </p>
+              <div class="flex flex-wrap gap-2">
+                {project.data.tags.slice(0, 4).map((tag) => (
+                  <span class="text-[9px] px-[10px] py-[3px] border border-phosphor-faint text-phosphor-text tracking-wider">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+
+    <!-- ── MINI GAME ── -->
+    <section class="py-16 border-b border-phosphor-border">
+      <div class="flex items-center gap-5 mb-10">
+        <span class="font-pixel text-[9px] text-phosphor-bright glow-text tracking-widest whitespace-nowrap">TAKE_A_BREAK.EXE</span>
+        <div class="section-rule"></div>
+      </div>
+      <div class="terminal-window inline-block overflow-hidden">
+        <div class="terminal-bar">
+          <div class="flex gap-[5px]">
+            <span class="terminal-dot"></span>
+            <span class="terminal-dot"></span>
+            <span class="terminal-dot"></span>
+          </div>
+          <span class="terminal-bar-title">MINIGAME.SYS</span>
+        </div>
+        <MiniGame />
+      </div>
+    </section>
+
   </main>
-  
+
   <Footer />
 </BaseLayout>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,5 +1,8 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import BackLink from '../../components/ui/BackLink.astro';
+import TerminalBar from '../../components/layout/TerminalBar.astro';
+import Tag from '../../components/ui/Tag.astro';
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 
@@ -13,28 +16,17 @@ export async function getStaticPaths() {
 
 const { project }: { project: CollectionEntry<'projects'> } = Astro.props;
 const { Content } = await project.render();
+const fileName = project.data.title.toUpperCase().replace(/\s+/g, '_');
 ---
 
 <BaseLayout title={`${project.data.title} | Joshua Knox`}>
   <main class="relative z-10 max-w-[1100px] mx-auto px-10 py-16">
 
-    <!-- Back link -->
-    <div class="mb-8 text-[11px]">
-      <a href="/projects" class="text-phosphor-dim hover:text-phosphor-bright transition-colors tracking-wider">
-        <span class="text-phosphor-faint">←</span> cd /projects
-      </a>
-    </div>
+    <BackLink href="/projects" label="/projects" />
 
     <!-- Header terminal window -->
     <div class="terminal-window mb-8">
-      <div class="terminal-bar">
-        <div class="flex gap-[5px]">
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-        </div>
-        <span class="terminal-bar-title">{project.data.title.toUpperCase().replace(/\s+/g, '_')}.EXE</span>
-      </div>
+      <TerminalBar title={`${fileName}.EXE`} />
       <div class="p-8">
         <h1 class="font-pixel text-phosphor-bright glow-text mb-5 leading-[1.4]" style="font-size: clamp(14px, 2.5vw, 24px);">
           {project.data.title}
@@ -55,31 +47,17 @@ const { Content } = await project.render();
         )}
 
         <div class="flex flex-wrap gap-2 mb-8">
-          {project.data.tags.map((tag) => (
-            <span class="text-[9px] px-[10px] py-[3px] border border-phosphor-faint text-phosphor-text tracking-wider">
-              {tag}
-            </span>
-          ))}
+          {project.data.tags.map((tag) => <Tag label={tag} />)}
         </div>
 
         <div class="flex flex-wrap gap-4">
           {project.data.demoUrl && (
-            <a
-              href={project.data.demoUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="btn-phosphor"
-            >
+            <a href={project.data.demoUrl} target="_blank" rel="noopener noreferrer" class="btn-phosphor">
               LIVE DEMO
             </a>
           )}
           {project.data.repoUrl && (
-            <a
-              href={project.data.repoUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="btn-ghost-phosphor"
-            >
+            <a href={project.data.repoUrl} target="_blank" rel="noopener noreferrer" class="btn-ghost-phosphor">
               source code
             </a>
           )}
@@ -89,14 +67,7 @@ const { Content } = await project.render();
 
     <!-- Content terminal window -->
     <div class="terminal-window">
-      <div class="terminal-bar">
-        <div class="flex gap-[5px]">
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-          <span class="terminal-dot"></span>
-        </div>
-        <span class="terminal-bar-title">README.md</span>
-      </div>
+      <TerminalBar title="README.md" />
       <div class="p-8">
         <article class="prose max-w-none">
           <Content />

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -16,71 +16,93 @@ const { Content } = await project.render();
 ---
 
 <BaseLayout title={`${project.data.title} | Joshua Knox`}>
-  <main class="container mx-auto px-4 py-16 md:py-24">
-    <div class="max-w-4xl mx-auto">
-      <!-- Back to Projects -->
-      <nav class="mb-8">
-        <a href="/projects" class="text-gameboy-light hover:text-gameboy-lightest flex items-center gap-2 group transition-colors">
-          <span class="group-hover:-translate-x-1 transition-transform">←</span> Back to Projects
-        </a>
-      </nav>
+  <main class="relative z-10 max-w-[1100px] mx-auto px-10 py-16">
 
-      <!-- Project Header -->
-      <header class="mb-12">
-        <h1 class="text-4xl md:text-6xl font-pixel text-gameboy-lightest mb-6 leading-tight">{project.data.title}</h1>
-        <p class="text-xl md:text-2xl text-tokyo-text mb-8 leading-relaxed max-w-3xl">{project.data.description}</p>
-        
+    <!-- Back link -->
+    <div class="mb-8 text-[11px]">
+      <a href="/projects" class="text-phosphor-dim hover:text-phosphor-bright transition-colors tracking-wider">
+        <span class="text-phosphor-faint">←</span> cd /projects
+      </a>
+    </div>
+
+    <!-- Header terminal window -->
+    <div class="terminal-window mb-8">
+      <div class="terminal-bar">
+        <div class="flex gap-[5px]">
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+        </div>
+        <span class="terminal-bar-title">{project.data.title.toUpperCase().replace(/\s+/g, '_')}.EXE</span>
+      </div>
+      <div class="p-8">
+        <h1 class="font-pixel text-phosphor-bright glow-text mb-5 leading-[1.4]" style="font-size: clamp(14px, 2.5vw, 24px);">
+          {project.data.title}
+        </h1>
+        <p class="text-[14px] text-phosphor-text leading-[1.9] mb-8 max-w-3xl">
+          {project.data.description}
+        </p>
+
         {project.data.heroImage && (
-          <div class="mb-12 rounded-xl overflow-hidden border border-tokyo-border shadow-2xl">
-            <img 
-              src={project.data.heroImage} 
-              alt={`${project.data.title} project screenshot`}
+          <div class="mb-8 border border-phosphor-border overflow-hidden">
+            <img
+              src={project.data.heroImage}
+              alt={`${project.data.title} screenshot`}
               class="w-full h-auto"
               loading="eager"
             />
           </div>
         )}
-        
-        <div class="flex flex-wrap gap-4 mb-8">
+
+        <div class="flex flex-wrap gap-2 mb-8">
           {project.data.tags.map((tag) => (
-            <span class="px-3 py-1 bg-tokyo-surface text-gameboy-light rounded border border-tokyo-border text-sm font-mono">
+            <span class="text-[9px] px-[10px] py-[3px] border border-phosphor-faint text-phosphor-text tracking-wider">
               {tag}
             </span>
           ))}
         </div>
 
-        <!-- Project Links -->
-        <div class="flex flex-wrap gap-6 text-lg">
+        <div class="flex flex-wrap gap-4">
           {project.data.demoUrl && (
-            <a 
-              href={project.data.demoUrl} 
-              target="_blank" 
+            <a
+              href={project.data.demoUrl}
+              target="_blank"
               rel="noopener noreferrer"
-              class="bg-gameboy-dark text-white px-6 py-3 rounded-lg font-pixel text-sm hover:bg-gameboy-light transition-all transform hover:scale-105 shadow-lg flex items-center gap-3"
+              class="btn-phosphor"
             >
-              <span>🚀</span> Live Demo
+              LIVE DEMO
             </a>
           )}
           {project.data.repoUrl && (
-            <a 
-              href={project.data.repoUrl} 
-              target="_blank" 
+            <a
+              href={project.data.repoUrl}
+              target="_blank"
               rel="noopener noreferrer"
-              class="border-2 border-gameboy-light text-gameboy-light px-6 py-3 rounded-lg font-pixel text-sm hover:border-gameboy-lightest hover:text-gameboy-lightest transition-all transform hover:scale-105 flex items-center gap-3"
+              class="btn-ghost-phosphor"
             >
-              <span>💻</span> Source Code
+              source code
             </a>
           )}
         </div>
-      </header>
-
-      <!-- Project Content -->
-      <article class="prose prose-invert prose-lg max-w-none mx-auto">
-        <Content />
-      </article>
-      
-      <!-- Mini Game Section (Removed from here too as per polish request focus on professional content) -->
-      <!-- <div class="mt-16">...</div> -->
+      </div>
     </div>
+
+    <!-- Content terminal window -->
+    <div class="terminal-window">
+      <div class="terminal-bar">
+        <div class="flex gap-[5px]">
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+        </div>
+        <span class="terminal-bar-title">README.md</span>
+      </div>
+      <div class="p-8">
+        <article class="prose max-w-none">
+          <Content />
+        </article>
+      </div>
+    </div>
+
   </main>
 </BaseLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,17 +1,21 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import SectionHeader from '../../components/layout/SectionHeader.astro';
+import TerminalBar from '../../components/layout/TerminalBar.astro';
+import Tag from '../../components/ui/Tag.astro';
 import { getCollection } from 'astro:content';
 
 const projects = await getCollection('projects');
+
+function fileName(title: string): string {
+  return title.toUpperCase().replace(/\s+/g, '_');
+}
 ---
 
 <BaseLayout title="Projects | Joshua Knox">
   <main class="relative z-10 max-w-[1100px] mx-auto px-10 py-16">
 
-    <div class="flex items-center gap-5 mb-12">
-      <span class="font-pixel text-[9px] text-phosphor-bright glow-text tracking-widest whitespace-nowrap">PROJECTS.LOG</span>
-      <div class="section-rule"></div>
-    </div>
+    <SectionHeader label="PROJECTS.LOG" marginClass="mb-12" />
 
     <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
       {projects.map((project) => (
@@ -20,14 +24,7 @@ const projects = await getCollection('projects');
           class="terminal-window block no-underline transition-all duration-200 group hover:border-phosphor-green"
           style="text-decoration: none;"
         >
-          <div class="terminal-bar">
-            <div class="flex gap-[5px]">
-              <span class="terminal-dot"></span>
-              <span class="terminal-dot"></span>
-              <span class="terminal-dot"></span>
-            </div>
-            <span class="terminal-bar-title">{project.data.title.toUpperCase().replace(/\s+/g, '_')}.EXE</span>
-          </div>
+          <TerminalBar title={`${fileName(project.data.title)}.EXE`} />
           <div class="p-7">
             <h2 class="font-pixel text-[10px] text-phosphor-bright group-hover:glow-text mb-3 leading-[1.7] tracking-wide transition-all">
               {project.data.title}
@@ -36,11 +33,7 @@ const projects = await getCollection('projects');
               {project.data.description}
             </p>
             <div class="flex flex-wrap gap-2 mb-5">
-              {project.data.tags.map((tag) => (
-                <span class="text-[9px] px-[10px] py-[3px] border border-phosphor-faint text-phosphor-text tracking-wider">
-                  {tag}
-                </span>
-              ))}
+              {project.data.tags.map((tag) => <Tag label={tag} />)}
             </div>
             <div class="text-[10px] text-phosphor-dim group-hover:text-phosphor-green transition-colors">
               <span class="text-phosphor-faint">$</span> view --details →

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,44 +1,53 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
-import MiniGame from '../../components/game/MiniGame.astro';
 
 const projects = await getCollection('projects');
 ---
 
 <BaseLayout title="Projects | Joshua Knox">
-  <main class="container mx-auto px-4 py-16 md:py-24">
-    <div class="max-w-6xl mx-auto">
-      <h1 class="text-4xl md:text-5xl font-pixel text-gameboy-lightest mb-12">PROJECTS</h1>
-      
-      <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-        {projects.map((project) => (
-          <a 
-            href={`/projects/${project.slug}`} 
-            class="group block bg-tokyo-surface border border-tokyo-border rounded-xl p-8 hover:border-gameboy-light transition-all hover:shadow-xl hover:shadow-gameboy-light/5 transform hover:-translate-y-1"
-          >
-            <h2 class="text-2xl font-pixel text-gameboy-light mb-4 group-hover:text-gameboy-lightest transition-colors">
+  <main class="relative z-10 max-w-[1100px] mx-auto px-10 py-16">
+
+    <div class="flex items-center gap-5 mb-12">
+      <span class="font-pixel text-[9px] text-phosphor-bright glow-text tracking-widest whitespace-nowrap">PROJECTS.LOG</span>
+      <div class="section-rule"></div>
+    </div>
+
+    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      {projects.map((project) => (
+        <a
+          href={`/projects/${project.slug}`}
+          class="terminal-window block no-underline transition-all duration-200 group hover:border-phosphor-green"
+          style="text-decoration: none;"
+        >
+          <div class="terminal-bar">
+            <div class="flex gap-[5px]">
+              <span class="terminal-dot"></span>
+              <span class="terminal-dot"></span>
+              <span class="terminal-dot"></span>
+            </div>
+            <span class="terminal-bar-title">{project.data.title.toUpperCase().replace(/\s+/g, '_')}.EXE</span>
+          </div>
+          <div class="p-7">
+            <h2 class="font-pixel text-[10px] text-phosphor-bright group-hover:glow-text mb-3 leading-[1.7] tracking-wide transition-all">
               {project.data.title}
             </h2>
-            <p class="text-tokyo-text mb-6 line-clamp-3 leading-relaxed">
+            <p class="text-[12px] text-phosphor-text leading-[1.9] mb-5 line-clamp-3">
               {project.data.description}
             </p>
-            
-            <div class="flex flex-wrap gap-2 mb-8">
+            <div class="flex flex-wrap gap-2 mb-5">
               {project.data.tags.map((tag) => (
-                <span class="text-xs px-2 py-1 bg-tokyo-bg text-tokyo-muted rounded border border-tokyo-border">
+                <span class="text-[9px] px-[10px] py-[3px] border border-phosphor-faint text-phosphor-text tracking-wider">
                   {tag}
                 </span>
               ))}
             </div>
-            
-            <div class="flex items-center gap-4 text-sm font-semibold text-gameboy-light group-hover:text-gameboy-lightest transition-colors mt-auto">
-              <span>View Details</span>
-              <span class="group-hover:translate-x-1 transition-transform">→</span>
+            <div class="text-[10px] text-phosphor-dim group-hover:text-phosphor-green transition-colors">
+              <span class="text-phosphor-faint">$</span> view --details →
             </div>
-          </a>
-        ))}
-      </div>
+          </div>
+        </a>
+      ))}
     </div>
   </main>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -51,23 +51,25 @@ body::after {
 }
 
 /* ─── Phosphor glow utilities ─── */
-.glow-text {
-  text-shadow:
-    0 0 8px #9bbc0f,
-    0 0 24px rgba(155, 188, 15, 0.35);
-}
+@layer utilities {
+  .glow-text {
+    text-shadow:
+      0 0 8px #9bbc0f,
+      0 0 24px rgba(155, 188, 15, 0.35);
+  }
 
-.glow-text-bright {
-  text-shadow:
-    0 0 12px #9bbc0f,
-    0 0 32px rgba(155, 188, 15, 0.35),
-    0 0 64px rgba(155, 188, 15, 0.12);
-}
+  .glow-text-bright {
+    text-shadow:
+      0 0 12px #b8e010,
+      0 0 40px rgba(184, 224, 16, 0.5),
+      0 0 80px rgba(184, 224, 16, 0.2);
+  }
 
-.glow-border {
-  box-shadow:
-    0 0 24px rgba(155, 188, 15, 0.25),
-    inset 0 0 40px rgba(155, 188, 15, 0.015);
+  .glow-border {
+    box-shadow:
+      0 0 24px rgba(155, 188, 15, 0.25),
+      inset 0 0 40px rgba(155, 188, 15, 0.015);
+  }
 }
 
 /* ─── Terminal window chrome ─── */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,37 +6,263 @@
 
 @layer base {
   body {
-    @apply font-sans;
+    @apply font-mono bg-phosphor-bg text-phosphor-green;
+    font-size: 13px;
+    line-height: 1.7;
   }
 }
 
-/* Custom GameBoy LCD effect */
-.gameboy-lcd {
-  background: linear-gradient(135deg, #9bbc0f 0%, #8bac0f 50%, #9bbc0f 100%);
-  filter: contrast(1.2) brightness(1.1);
+/* ─── CRT Scanlines ─── */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.06) 2px,
+    rgba(0, 0, 0, 0.06) 4px
+  );
+  pointer-events: none;
+  z-index: 9999;
 }
 
-/* Pixel perfect rendering */
+/* ─── CRT Vignette ─── */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(ellipse at center, transparent 55%, rgba(0, 0, 0, 0.75) 100%);
+  pointer-events: none;
+  z-index: 9998;
+}
+
+/* ─── Phosphor grid bg ─── */
+.phosphor-grid {
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(155, 188, 15, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(155, 188, 15, 0.035) 1px, transparent 1px);
+  background-size: 48px 48px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ─── Phosphor glow utilities ─── */
+.glow-text {
+  text-shadow:
+    0 0 8px #9bbc0f,
+    0 0 24px rgba(155, 188, 15, 0.35);
+}
+
+.glow-text-bright {
+  text-shadow:
+    0 0 12px #9bbc0f,
+    0 0 32px rgba(155, 188, 15, 0.35),
+    0 0 64px rgba(155, 188, 15, 0.12);
+}
+
+.glow-border {
+  box-shadow:
+    0 0 24px rgba(155, 188, 15, 0.25),
+    inset 0 0 40px rgba(155, 188, 15, 0.015);
+}
+
+/* ─── Terminal window chrome ─── */
+.terminal-window {
+  @apply bg-phosphor-surface border border-phosphor-border;
+}
+
+.terminal-bar {
+  @apply bg-phosphor-faint border-b border-phosphor-border;
+  padding: 10px 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.terminal-dot {
+  width: 7px;
+  height: 7px;
+  background: #5a7a08;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.terminal-bar-title {
+  @apply font-pixel text-phosphor-text;
+  font-size: 7px;
+  letter-spacing: 0.08em;
+}
+
+/* ─── Blinking cursor ─── */
+.cursor-blink {
+  display: inline-block;
+  width: 3px;
+  height: 0.85em;
+  background: #b8e010;
+  box-shadow: 0 0 8px #9bbc0f;
+  margin-left: 4px;
+  vertical-align: middle;
+  animation: cursorBlink 1.1s step-end infinite;
+}
+
+@keyframes cursorBlink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* ─── Stat bar fill animation ─── */
+.stat-bar-fill {
+  animation: fillBar 1.8s ease-out forwards;
+}
+
+@keyframes fillBar {
+  from { width: 0; }
+  to { width: var(--pct); }
+}
+
+/* ─── Status dot pulse ─── */
+.status-dot {
+  width: 6px;
+  height: 6px;
+  background: #9bbc0f;
+  box-shadow: 0 0 6px #9bbc0f;
+  display: inline-block;
+  animation: statusPulse 2s ease-in-out infinite;
+}
+
+@keyframes statusPulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 6px #9bbc0f; }
+  50% { opacity: 0.3; box-shadow: none; }
+}
+
+/* ─── Nav link prompt prefix ─── */
+.nav-link::before {
+  content: '> ';
+  color: #2e3e06;
+}
+
+/* ─── Phosphor buttons ─── */
+.btn-phosphor {
+  padding: 13px 28px;
+  background: #9bbc0f;
+  color: #060a06;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-decoration: none;
+  display: inline-block;
+  box-shadow: 0 0 14px rgba(155, 188, 15, 0.35), 0 0 40px rgba(155, 188, 15, 0.1);
+  transition: all 0.15s;
+}
+
+.btn-phosphor:hover {
+  background: #b8e010;
+  box-shadow: 0 0 24px #9bbc0f, 0 0 60px rgba(155, 188, 15, 0.35);
+}
+
+.btn-ghost-phosphor {
+  padding: 13px 28px;
+  border: 1px solid #6a8a0a;
+  color: #6a8a0a;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-decoration: none;
+  display: inline-block;
+  transition: all 0.15s;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.btn-ghost-phosphor::before {
+  content: '$ ';
+  color: #5a7a08;
+}
+
+.btn-ghost-phosphor:hover {
+  border-color: #9bbc0f;
+  color: #b8e010;
+  text-shadow: 0 0 6px #9bbc0f;
+}
+
+/* ─── Section rule ─── */
+.section-rule {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, #6a8a0a, transparent);
+}
+
+/* ─── Pixel-perfect image rendering ─── */
 .pixel-perfect {
   image-rendering: pixelated;
   image-rendering: -moz-crisp-edges;
   image-rendering: crisp-edges;
 }
 
-/* Custom scrollbar */
+/* ─── Custom scrollbar ─── */
 ::-webkit-scrollbar {
-  width: 8px;
+  width: 6px;
 }
 
 ::-webkit-scrollbar-track {
-  background: #1a1b26;
+  background: #060a06;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #414868;
-  border-radius: 4px;
+  background: #2e3e06;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #565f89;
+  background: #6a8a0a;
+}
+
+/* ─── Prose overrides for blog posts ─── */
+.prose {
+  color: #5a7a08;
+}
+
+.prose h1, .prose h2, .prose h3 {
+  color: #b8e010;
+  font-family: 'Press Start 2P', monospace;
+  text-shadow: 0 0 8px #9bbc0f;
+}
+
+.prose a {
+  color: #9bbc0f;
+  text-decoration: none;
+}
+
+.prose a:hover {
+  color: #b8e010;
+  text-shadow: 0 0 6px #9bbc0f;
+}
+
+.prose code {
+  color: #9bbc0f;
+  background: #0d140d;
+  border: 1px solid #1a2e1a;
+  padding: 0.15rem 0.4rem;
+  font-size: 0.85em;
+}
+
+.prose pre {
+  background: #0d140d;
+  border: 1px solid #1a2e1a;
+}
+
+.prose blockquote {
+  border-left-color: #6a8a0a;
+  color: #5a7a08;
+}
+
+.prose strong {
+  color: #9bbc0f;
+}
+
+/* ─── Legacy gameboy-lcd (keep for MiniGame) ─── */
+.gameboy-lcd {
+  background: linear-gradient(135deg, #9bbc0f 0%, #8bac0f 50%, #9bbc0f 100%);
+  filter: contrast(1.2) brightness(1.1);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,16 @@ export default {
   theme: {
     extend: {
       colors: {
+        'phosphor': {
+          'bg': '#060a06',
+          'surface': '#0d140d',
+          'border': '#1a2e1a',
+          'green': '#9bbc0f',
+          'bright': '#b8e010',
+          'dim': '#6a8a0a',
+          'faint': '#2e3e06',
+          'text': '#5a7a08',
+        },
         'gameboy': {
           'darkest': '#0f380f',
           'dark': '#306230',


### PR DESCRIPTION
## Summary

- Complete visual redesign to CRT phosphor terminal aesthetic (Option A)
- Phosphor green (#9bbc0f/#b8e010) on dark (#060a06) background throughout
- CRT scanlines + vignette via CSS pseudo-elements on body
- All pages use terminal window chrome pattern (`.terminal-window`, `.terminal-bar`, `.terminal-dot`)
- Two-column hero with animated STATS.SYS skill bar panel (CSS `@keyframes fillBar` + `--pct` custom property)
- Header nav with `>` prompt prefix, footer with pulsing status dot
- Games page uses `.ROM` naming, blog cards use `YYYY-MM-DD.md` date format
- Adds `CLAUDE.md` with project commands and architecture overview

## Validation

- `bun run typecheck` — 0 errors
- `bun run build` — clean build, 25 pages generated
- E2e tests: nav/content tests pass; search keyboard-nav failures are pre-existing (unrelated to this PR)
- Visual QA at 1440px and 375px confirmed design matches Option A mockup

## Test plan

- [ ] Visit `/` — two-column hero, STATS.SYS panel with animated bars, CRT overlay
- [ ] Visit `/projects` — terminal card grid
- [ ] Visit `/blog` — date-stamped terminal cards
- [ ] Visit `/games` — `.ROM` file cards + Code Runner teaser
- [ ] Mobile (375px) — single column, no layout breakage
- [ ] Dark background with phosphor glow visible throughout

🤖 Generated with [Claude Code](https://claude.ai/claude-code)