### PR TITLE
Fix factual inaccuracies in 12 project posts

### DIFF
--- a/src/content/projects/agentic-sdlc-framework.md
+++ b/src/content/projects/agentic-sdlc-framework.md
@@ -15,7 +15,7 @@ A structured approach to agentic development:
 - **F**ocus: Define what we're building
 - **R**equirements: Gather and document needs
 - **A**utomate: Let AI agents handle implementation
-- **M**easure: Verify it works
+- **M**ulti-agent: Dispatch specialized AI agents
 - **E**valuate: Decide to ship or iterate
 
 ## Key Features
@@ -32,7 +32,4 @@ In regulated industries, speed and compliance are often at odds. This framework 
 ## Tech Stack
 
 - Python for core framework
-- Integration with multiple LLM providers
-- SQLite for audit logging
-- Docker for isolation
 - GitHub Actions for CI/CD

--- a/src/content/projects/chicken-mob.md
+++ b/src/content/projects/chicken-mob.md
@@ -1,6 +1,6 @@
 ---
 title: "Chicken Mob"
-description: "A fast-paced, lane-based crowd game with chickens. Because why not? Built with TypeScript and Canvas."
+description: "A fast-paced cannon-launching crowd game with chickens. Fire flocks through multiplier gates. Because why not? Built with TypeScript and Canvas."
 pubDate: 2026-04-01
 tags: ["TypeScript", "Canvas", "Web Audio", "Game"]
 repoUrl: "https://github.com/bigknoxy/chicken-mob"
@@ -8,24 +8,25 @@ heroImage: "/assets/images/projects/chicken-mob-hero.svg"
 featured: true
 ---
 
-## Herd the Chickens!
+## Launch the Chickens!
 
-Chicken Mob is a lane-based crowd game where you control a chicken herder trying to manage... well, a mob of chickens.
+Chicken Mob is a barn-cannon game where you aim and fire chicken flocks through multiplier gates. It's like angry birds meets a crowd simulator, if the birds were chickens and the crowd was a mob.
 
 ## Features
 
-- **Lane-based gameplay**: Chickens run in lanes, you switch between them
-- **Power-ups**: Collect corn to speed up, avoid obstacles
-- **Increasing difficulty**: More chickens, faster speeds, more chaos
-- **Original chicken sounds**: Yes, I recorded actual chickens
-- **Retro pixel art**: Deliberately charming visuals
+- **Barn cannons**: 3 unique cannons with different firing patterns
+- **Multiplier gates**: Fire chickens through gates to grow your flock
+- **5 chicken types**: Clucky, Hen Tank, Rooster Bomber, Speed Chick, Golden Goose
+- **3 fox enemies**: Scout, Brute, and Sniper foxes try to stop you
+- **15 hand-authored levels**: Progressive difficulty from tutorial to multi-lane boss battles
+- **Offline income**: Chicken Coop generates corn while you're away
+- **Meta progression**: Unlock and upgrade your arsenal between runs
 
 ## Technical Highlights
 
-- Object pooling for 500+ chickens at 60fps
-- Canvas-based rendering with dirty rectangles
-- Web Audio API for positional sound
-- Mobile touch controls
+- Count-based aggregate mob rendering for hundreds of units at 60fps
+- Canvas 2D rendering with procedural audio via Web Audio API
+- Mobile touch controls with portrait orientation lock
 - Progressive Web App support
 
 ## Why Chickens?

--- a/src/content/projects/chop-it-like-its-hawt.md
+++ b/src/content/projects/chop-it-like-its-hawt.md
@@ -1,6 +1,6 @@
 ---
 title: "Chop It Like It's Hawt"
-description: "An incremental clicker game about chopping vegetables. Absurd, satisfying, and weirdly addictive."
+description: "An incremental clicker game about chopping trees, crafting axes, and building an idle forest. Absurd, satisfying, and weirdly addictive."
 pubDate: 2026-05-01
 tags: ["TypeScript", "Vite", "Incremental Game", "Game"]
 repoUrl: "https://github.com/bigknoxy/chop-it-like-its-hawt"
@@ -8,26 +8,36 @@ heroImage: "/assets/images/projects/chop-hawt-hero.svg"
 featured: true
 ---
 
-## The Vegetable Chopping Simulator You Didn't Know You Needed
+## The Tree Chopping Simulator You Didn't Know You Needed
 
-Click to chop. Earn chop points. Buy upgrades. Watch numbers go up. Feel strangely accomplished.
+Click to chop trees. Collect wood. Upgrade your axe. Watch numbers go up. Build a forest that works for you while you're away. Feel strangely accomplished.
 
-## The Vegetables
+## Gameplay
 
-Start simple, get absurd:
-- Level 1: Carrots
-- Level 5: Potatoes
-- Level 10: Pumpkins
-- Level 25: Watermelons
-- Level 50: A whole durian
-- Level 100: A log cabin made of vegetables (don't ask)
+- **Chop trees** — Click or hold to chop down trees and collect wood
+- **Upgrade your axe** — Improve chopping power with new axes and abilities
+- **Unlock upgrades** — Boost strength, crit chance, auto-chop, and more
+- **Explore biomes** — Discover rare woods across unique regions including Crystal Caverns and Volcanic Grove
+- **Prestige your forest** — Rebirth for Growth Essence and permanent bonuses
+- **Build your forest** — Earn idle wood while you're away
+- **Complete daily quests** — Claim rewards for chopping, collecting wood, and upgrading
+- **Earn achievements** — Stack permanent bonuses and skill tree upgrades
 
-## Upgrades
+## Biomes
 
-- Sharper knives (more points per chop)
-- Faster chopping (auto-click)
-- Auto-choppers (chop while AFK)
-- Prestige system (do it all again, but faster)
+Start in the Forest, then unlock new worlds with rare wood types:
+
+- **Forest** — Your classic trees. Reliable, steady, home.
+- **Crystal Caverns** — Glowing crystalline trees with unique resources
+- **Volcanic Grove** — Blazing hot wood for the brave lumberjack
+
+## Axes & Upgrades
+
+- **Multiple axe types** with unique abilities and damage
+- **Crit chance** upgrades for big hits
+- **Auto-chop** so your lumberjack works even when you don't
+- **Forest workers** generate idle income while you're AFK
+- **Skill tree** with Growth Essence for permanent progression
 
 ## Why Make This?
 
@@ -38,8 +48,8 @@ Also, I wanted to learn more about:
 - Save/load systems
 - Offline progress calculation
 - Big number handling
+- Idle game economy design
 
 ## Play Now
 
 [Chop It Like It's Hawt](https://bigknoxy.github.io/chop-it-like-its-hawt)
-

--- a/src/content/projects/exa-cli.md
+++ b/src/content/projects/exa-cli.md
@@ -15,7 +15,7 @@ exa-cli brings the power of Exa's AI search to your terminal:
 - **Semantic search**: Find relevant content, not just keyword matches
 - **Web crawling**: Extract content from pages automatically
 - **Research summaries**: Get AI-generated summaries of findings
-- **Export options**: Save results as JSON, Markdown, or HTML
+- **Export options**: Save results as text, JSON, or Markdown
 - **MCP integration**: Works with Claude and other MCP clients
 
 ## Why Exa?

--- a/src/content/projects/frame-kit.md
+++ b/src/content/projects/frame-kit.md
@@ -15,48 +15,49 @@ featured: true
 
 # frame-kit
 
-**frame-kit** is a shell-native implementation of the agentic FRAME loop — Focus, Requirements, Automate, Measure, Evaluate — designed for developers who live in the terminal and want AI-assisted development without leaving their workflow.
+**frame-kit** is a Claude Code plugin that implements the agentic FRAME loop — Focus, Requirements, Automate, Multi-agent, Evaluate — right inside your Claude Code sessions.
 
-## The FRAME Loop, Terminal-Native
+## The FRAME Loop in Claude Code
 
-frame-kit brings the structured agentic development cycle straight to your shell:
+frame-kit brings structured agentic development to Claude Code with chat commands:
 
-- **F**ocus: Define what you're building with a simple prompt
-- **R**equirements: Auto-gather and document what the project needs
-- **A**utomate: Dispatch AI agents to handle the implementation
-- **M**easure: Run tests, checks, and validation automatically
+- **F**ocus: `/focus` — Define what you're building with a clear prompt
+- **R**equirements: `/spec` — Auto-gather and document project requirements
+- **A**utomate: Dispatch AI agents to handle implementation
+- **M**ulti-agent: `/handoff` — Pass context between specialized agents
 - **E**valuate: Review results and decide — ship it or iterate
 
-## Why Shell?
+## Why Claude Code?
 
-Because your terminal is home. frame-kit:
+Claude Code is your terminal-based AI coding partner. frame-kit layers structure on top:
 
-- Works with any POSIX-compatible shell
-- Zero runtime dependencies — just bash and curl
-- Integrates with your existing aliases, scripts, and tooling
-- Pipes everywhere — compose with grep, jq, fzf, whatever you want
-- Fast. Like, *really* fast. No Node_modules in sight.
+- **FRAME commands**: `/frame-init`, `/spec`, `/handoff` for guided development
+- **Checkpointing**: Save and resume FRAME sessions within Claude Code
+- **Templates**: Reusable project templates for common workflows
+- **Skills**: Composable agent skills for specialized tasks
 
 ## Key Features
 
-- **Interactive mode**: Step through each FRAME phase with guided prompts
-- **Automated mode**: Run the full loop hands-free for well-defined tasks
-- **Checkpointing**: Save and resume FRAME sessions
-- **Composable**: Pipe FRAME outputs into other tools
-- **Lightweight**: The whole thing is shell scripts. Seriously.
+- **Chat commands**: `/frame-init` starts a new FRAME session
+- **Spec generation**: `/spec` creates structured requirements documents
+- **Agent handoff**: `/handoff` passes context between agents cleanly
+- **Checkpointing**: Save progress and resume later
+- **Lightweight**: Pure shell scripts, integrates with existing Claude Code setup
 
 ## Getting Started
 
+Install via Claude Code plugin marketplace:
 ```bash
-git clone https://github.com/bigknoxy/frame-kit.git
-cd frame-kit
-chmod +x frame
-./frame init
-./frame start --interactive
+/plugin marketplace add bigknoxy/frame-kit
+```
+
+Then start a session:
+```bash
+/frame-init
 ```
 
 ## Philosophy
 
-The best tools get out of your way. frame-kit doesn't try to be an IDE, a framework, or a platform. It's just a loop — a really useful one that happens to fit perfectly in your terminal.
+The best tools get out of your way. frame-kit doesn't try to be an IDE, a framework, or a platform. It's just a loop — a really useful one that happens to fit perfectly in your terminal workflow.
 
 Source Code: [GitHub (frame-kit)](https://github.com/bigknoxy/frame-kit)

--- a/src/content/projects/ghAuto.md
+++ b/src/content/projects/ghAuto.md
@@ -36,7 +36,9 @@ ghAuto helps you:
 ## Getting Started
 
 ```bash
-pip install ghauto
+git clone https://github.com/bigknoxy/ghAuto
+cd ghAuto
+pip install -e .
 ghauto auth
 ghauto analyze --user bigknoxy
 ```

--- a/src/content/projects/hashpilot.md
+++ b/src/content/projects/hashpilot.md
@@ -3,7 +3,7 @@ title: "HashPilot"
 description: "Global, tool-agnostic structured editing core for AI coding agents. Provides syntax-aware editing via tree-sitter, hash-anchored content replacement, and batched verification — integrated with Claude Code, OpenCode, and Pi."
 pubDate: 2026-05-05
 tags: ["TypeScript", "Bun", "tree-sitter", "AST", "AI Tooling", "Developer Tools"]
-repoUrl: "https://github.com/bigknoxy/HashPilot"
+repoUrl: ""
 featured: false
 ---
 
@@ -31,8 +31,4 @@ When AI agents edit files in multi-step workflows, earlier edits shift line numb
 
 ## Integrations
 
-Adapters for Claude Code, OpenCode, and Pi are installed automatically:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/bigknoxy/HashPilot/main/scripts/install.sh | sh
-```
+Adapters for Claude Code, OpenCode, and Pi are included in the local install.

--- a/src/content/projects/ideavault.md
+++ b/src/content/projects/ideavault.md
@@ -47,7 +47,7 @@ Because your ideas deserve speed:
 ## Getting Started
 
 ```bash
-cargo install ideavault
+curl -fsSL https://raw.githubusercontent.com/bigknoxy/ideavault/main/install.sh | bash
 ideavault init
 ideavault add "Build a compiler for emoji" --tags "crazy,side-project"
 ideavault search "emoji"

--- a/src/content/projects/joshbot.md
+++ b/src/content/projects/joshbot.md
@@ -36,7 +36,7 @@ Go was chosen for:
 ## Getting Started
 
 ```bash
-go install github.com/bigknoxy/joshbot@latest
+go install github.com/bigknoxy/joshbot/cmd/joshbot@latest
 joshbot init
 joshbot chat
 ```

--- a/src/content/projects/smashmine.md
+++ b/src/content/projects/smashmine.md
@@ -28,8 +28,7 @@ featured: true
 
 - **TypeScript**: Type-safe game development
 - **PWA**: Installable progressive web app
-- **Voxel Engine**: Custom voxel rendering
-- **WebGL**: Hardware-accelerated graphics
+- **Three.js**: WebGL-powered 3D rendering with custom voxel meshing
 
 ## Play Now
 

--- a/src/content/projects/team-ai-warehouse.md
+++ b/src/content/projects/team-ai-warehouse.md
@@ -19,13 +19,13 @@ AI coding tools each have their own skill/command systems. Team AI Warehouse sta
 
 | Command | Description |
 |---------|-------------|
-| `uaa init` | Initialize warehouse |
-| `uaa sync --all` | Sync skills to all 4 tools |
-| `uaa status` | Show skill counts per tool |
-| `uaa list` | List all available skills |
-| `uaa validate` | Validate SKILL.md files |
-| `uaa tag v1.0.0` | Create version tag |
-| `uaa contrib <skill>` | Create PR for a new skill |
+| `python3 scripts/uaa init` | Initialize warehouse |
+| `python3 scripts/uaa sync --all` | Sync skills to all 4 tools |
+| `python3 scripts/uaa status` | Show skill counts per tool |
+| `python3 scripts/uaa list` | List all available skills |
+| `python3 scripts/uaa validate` | Validate SKILL.md files |
+| `python3 scripts/uaa tag v1.0.0` | Create version tag |
+| `python3 scripts/uaa contrib <skill>` | Create PR for a new skill |
 
 ## Structure
 

--- a/src/content/projects/toilet-runner.md
+++ b/src/content/projects/toilet-runner.md
@@ -20,7 +20,7 @@ featured: false
 ## Gameplay
 
 - **Endless Running**: Keep rolling as long as you can
-- **3D Obstacles**: Dodge poop, plungers, and other bathroom hazards
+- **3D Obstacles**: Dodge piles of poop on a three-lane path
 - **Silly Theme**: Embrace the absurdity
 - **High Score**: Compete for the longest run
 


### PR DESCRIPTION
## Summary

Fact-checked all 24 project posts against their GitHub repos. Fixed 12 files spanning critical rewrites, medium corrections, and minor tweaks.

### Critical rewrites (3)
- **chop-it-like-its-hawt**: vegetable chopping with knives → tree chopping with axes, wood currency, biomes, achievements, skill tree, daily quests, prestige
- **chicken-mob**: lane herding → cannon-launching through multiplier gates with 15 hand-authored levels
- **frame-kit**: standalone CLI tool with  → Claude Code plugin (no `frame` executable exists)

### Medium fixes (4)
- **agentic-sdlc-framework**: FRAME acronym M=Measure→Multi-agent; removed unverified LLM/SQLite/Docker claims
- **ghAuto/joshbot/ideavault**: corrected install commands to match READMEs

### Minor fixes (5)
- **exa-cli**: removed unsupported HTML export format
- **toilet-runner**: removed inaccurate plunger obstacles
- **smashmine**: added Three.js credit, removed misleading "custom voxel engine"
- **team-ai-warehouse**: commands prefixed with `python3 scripts/`
- **hashpilot**: removed dead 404 repo URL

### Verification
- `bun run build` passes
- Editor subagent reviewed all rewrites for tone and accuracy

### Unchanged
12 projects verified as fully accurate: TurboHop, Pew Run, auto-portfolio, flight-deal-monitor, jeetSocial, joshify, kTracker, opencode-skill-evolution, self-evolving-dev-ecosystem, sqlOptimizer, swarm-agent, tiny-fixers