### PR TITLE
fix: search mark tags rendering as literal text

### DIFF
--- a/src/components/ui/SearchBar.astro
+++ b/src/components/ui/SearchBar.astro
@@ -2,6 +2,15 @@
 // SearchBar.astro - Pagefind integration
 ---
 
+<style>
+  mark {
+    background: rgba(115, 195, 255, 0.2);
+    color: #73c3ff;
+    border-radius: 2px;
+    padding: 0 2px;
+  }
+</style>
+
 <div class="relative max-w-md mx-auto">
   <label for="search-input" class="sr-only">Search posts</label>
   <input
@@ -114,7 +123,10 @@
       titleEl.textContent = r.title;
       const excerptEl = document.createElement('div');
       excerptEl.className = 'font-mono text-[10px] text-phosphor-text mt-1';
-      excerptEl.textContent = r.excerpt || '';
+      // Pagefind returns excerpts with <mark> tags for highlighted matches.
+      // Strip any non-mark tags for safety, then render marks as real HTML.
+      const safeExcerpt = (r.excerpt || '').replace(/<\/?((?!mark\b)[^>]+)>/gi, '');
+      excerptEl.innerHTML = safeExcerpt;
       a.appendChild(titleEl);
       a.appendChild(excerptEl);
       a.tabIndex = -1; // focusable programmatically


### PR DESCRIPTION
## Summary

Fixes #1 — SearchBar was displaying literal `<mark>` HTML tags instead of properly rendered highlights.

## Root Cause

Pagefind returns excerpts with `<mark>` tags around matched terms (e.g., `<mark>jeet</mark>`). The code was using `textContent` to set the excerpt, which HTML-escapes the content, causing the `<mark>` tags to appear as visible text.

## Fix

1. Changed excerpt rendering from `textContent` → `innerHTML` with a safety regex that strips any non-`<mark>` tags
2. Added themed `<mark>` styling (Tokyo Night-inspired blue highlight) to match the site aesthetic

## Changes

- `src/components/ui/SearchBar.astro`:
  - Line 117: Replace `textContent` with `innerHTML` + safe excerpt sanitizer
  - Added `<style>` block for `<mark>` highlight styling

## Testing

- [x] Search for a term → excerpts now show highlighted matches
- [x] No literal `<mark>` tags visible
- [x] XSS safety: non-mark tags are stripped before rendering

Closes #1